### PR TITLE
Implement pydantic config system

### DIFF
--- a/src/causal_consistency_nn/config.py
+++ b/src/causal_consistency_nn/config.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+import os
+
+import yaml
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+@dataclass
+class ModelConfig:
+    """Architecture hyperparameters."""
+
+    hidden_dim: int = 64
+    num_layers: int = 2
+
+
+@dataclass
+class LossWeights:
+    """Weighting of individual loss terms."""
+
+    z_yx: float = 1.0
+    y_xz: float = 1.0
+    x_yz: float = 1.0
+    unsup: float = 0.0
+
+
+@dataclass
+class TrainingConfig:
+    """General training parameters."""
+
+    batch_size: int = 32
+    epochs: int = 10
+    learning_rate: float = 1e-3
+    device: str = "cpu"
+
+
+class Settings(BaseSettings):
+    """Global configuration loaded from environment variables or a YAML file."""
+
+    model: ModelConfig = Field(default_factory=ModelConfig)
+    loss: LossWeights = Field(default_factory=LossWeights)
+    train: TrainingConfig = Field(default_factory=TrainingConfig)
+    config_path: str | None = None
+
+    model_config = SettingsConfigDict(env_nested_delimiter="__")
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> "Settings":
+        """Load configuration from a YAML file, allowing env overrides."""
+        data: dict[str, Any] = {}
+        with Path(path).open("r") as handle:
+            data = yaml.safe_load(handle) or {}
+
+        env_map = {
+            "model": ModelConfig,
+            "loss": LossWeights,
+            "train": TrainingConfig,
+        }
+        for section, dc in env_map.items():
+            if section in data:
+                for field in list(dc.__annotations__):
+                    env_var = f"{section.upper()}__{field.upper()}"
+                    if env_var in os.environ:
+                        data[section].pop(field, None)
+                if not data[section]:
+                    data.pop(section)
+
+        return cls(**data, config_path=str(path))

--- a/src/causal_consistency_nn/train.py
+++ b/src/causal_consistency_nn/train.py
@@ -1,7 +1,66 @@
 """Training entry point."""
 
+from __future__ import annotations
 
-def main() -> None:
+import argparse
+from pathlib import Path
+
+import yaml
+
+from .config import Settings
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Parse configuration and launch training (placeholder)."""
+    parser = argparse.ArgumentParser(description="Training script")
+    parser.add_argument("--config", type=str, help="Path to YAML config file")
+    parser.add_argument("--model-hidden-dim", type=int)
+    parser.add_argument("--model-num-layers", type=int)
+    parser.add_argument("--loss-z-yx", type=float)
+    parser.add_argument("--loss-y-xz", type=float)
+    parser.add_argument("--loss-x-yz", type=float)
+    parser.add_argument("--loss-unsup", type=float)
+    args = parser.parse_args(argv)
+
+    data: dict[str, object] = {}
+    if args.config:
+        with Path(args.config).open("r") as handle:
+            data = yaml.safe_load(handle) or {}
+
+    overrides: dict[str, dict[str, float | int]] = {}
+    if args.model_hidden_dim is not None or args.model_num_layers is not None:
+        overrides["model"] = {}
+        if args.model_hidden_dim is not None:
+            overrides["model"]["hidden_dim"] = args.model_hidden_dim
+        if args.model_num_layers is not None:
+            overrides["model"]["num_layers"] = args.model_num_layers
+
+    if (
+        args.loss_z_yx is not None
+        or args.loss_y_xz is not None
+        or args.loss_x_yz is not None
+        or args.loss_unsup is not None
+    ):
+        overrides["loss"] = {}
+        if args.loss_z_yx is not None:
+            overrides["loss"]["z_yx"] = args.loss_z_yx
+        if args.loss_y_xz is not None:
+            overrides["loss"]["y_xz"] = args.loss_y_xz
+        if args.loss_x_yz is not None:
+            overrides["loss"]["x_yz"] = args.loss_x_yz
+        if args.loss_unsup is not None:
+            overrides["loss"]["unsup"] = args.loss_unsup
+
+    merged: dict[str, object] = {**data}
+    for key, value in overrides.items():
+        if key in merged and isinstance(merged[key], dict):
+            merged[key].update(value)
+        else:
+            merged[key] = value
+
+    settings = Settings(**merged, config_path=args.config)
+
+    print(f"Using config: {settings}")
     print("Training placeholder")
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from causal_consistency_nn.config import Settings
+
+
+def test_settings_from_yaml(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        """
+model:
+  hidden_dim: 128
+loss:
+  x_yz: 0.5
+train:
+  batch_size: 16
+"""
+    )
+    s = Settings.from_yaml(cfg)
+    assert s.model.hidden_dim == 128
+    assert s.loss.x_yz == 0.5
+    assert s.train.batch_size == 16
+
+
+def test_settings_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("model:\n  num_layers: 1\n")
+    monkeypatch.setenv("MODEL__NUM_LAYERS", "4")
+    s = Settings.from_yaml(cfg)
+    assert s.model.num_layers == 4

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from causal_consistency_nn import train
+
+
+def test_cli_override(tmp_path: Path, capsys) -> None:
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("loss:\n  unsup: 0.1\n")
+    train.main(["--config", str(cfg), "--loss-unsup", "0.5"])
+    out = capsys.readouterr().out
+    assert "unsup=0.5" in out


### PR DESCRIPTION
## Summary
- add dataclass-based config objects and pydantic Settings loader
- allow Settings to read from YAML while letting env variables override
- parse Settings in `train.py` with CLI override support
- add tests for Settings and CLI parsing

## Testing
- `ruff check .`
- `black src/causal_consistency_nn/config.py`
- `black src/causal_consistency_nn/train.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685298bb48e483249e8208e3ed6cbf77