### PR TITLE
Implement conditional heads

### DIFF
--- a/src/causal_consistency_nn/model/heads.py
+++ b/src/causal_consistency_nn/model/heads.py
@@ -1,15 +1,90 @@
-"""Placeholder heads."""
+"""Neural network heads producing conditional distributions."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 
-def z_given_xy() -> str:
-    return "Z|XY"
-
-
-def y_given_xz() -> str:
-    return "Y|XZ"
+import torch
+from torch import nn
+from torch.distributions import Categorical, Normal
 
 
-def x_given_yz() -> str:
-    return "X|YZ"
+@dataclass
+class ZgivenXYConfig:
+    """Configuration for :class:`ZgivenXY`."""
+
+    h_dim: int
+    y_dim: int
+    z_dim: int
+
+
+@dataclass
+class YgivenXZConfig:
+    """Configuration for :class:`YgivenXZ`."""
+
+    h_dim: int
+    z_dim: int
+    y_dim: int
+
+
+@dataclass
+class XgivenYZConfig:
+    """Configuration for :class:`XgivenYZ`."""
+
+    h_dim: int
+    y_dim: int
+    x_dim: int
+
+
+class ZgivenXY(nn.Module):
+    """Distribution of ``Z`` given ``X`` and ``Y``."""
+
+    def __init__(self, cfg: ZgivenXYConfig) -> None:  # noqa: D401
+        super().__init__()
+        self.cfg = cfg
+        self.fc = nn.Linear(cfg.h_dim + cfg.y_dim, 2 * cfg.z_dim)
+
+    def forward(self, h: torch.Tensor, y_onehot: torch.Tensor) -> Normal:
+        """Return ``p(Z | X,Y)`` as a Normal distribution."""
+        out = self.fc(torch.cat([h, y_onehot], dim=-1))
+        mu, log_sigma = out.chunk(2, dim=-1)
+        return Normal(mu, log_sigma.exp())
+
+
+class YgivenXZ(nn.Module):
+    """Distribution of ``Y`` given ``X`` and ``Z``."""
+
+    def __init__(self, cfg: YgivenXZConfig) -> None:  # noqa: D401
+        super().__init__()
+        self.cfg = cfg
+        self.fc = nn.Linear(cfg.h_dim + cfg.z_dim, cfg.y_dim)
+
+    def forward(self, h: torch.Tensor, z: torch.Tensor) -> Categorical:
+        """Return ``p(Y | X,Z)`` as a Categorical distribution."""
+        logits = self.fc(torch.cat([h, z], dim=-1))
+        return Categorical(logits=logits)
+
+
+class XgivenYZ(nn.Module):
+    """Distribution of ``X`` given ``Y`` and ``Z``."""
+
+    def __init__(self, cfg: XgivenYZConfig) -> None:  # noqa: D401
+        super().__init__()
+        self.cfg = cfg
+        self.fc = nn.Linear(cfg.h_dim + cfg.y_dim, 2 * cfg.x_dim)
+
+    def forward(self, h: torch.Tensor, y_onehot: torch.Tensor) -> Normal:
+        """Return ``p(X | Y,Z)`` as a Normal distribution."""
+        out = self.fc(torch.cat([h, y_onehot], dim=-1))
+        mu, log_sigma = out.chunk(2, dim=-1)
+        return Normal(mu, log_sigma.exp())
+
+
+__all__ = [
+    "ZgivenXY",
+    "YgivenXZ",
+    "XgivenYZ",
+    "ZgivenXYConfig",
+    "YgivenXZConfig",
+    "XgivenYZConfig",
+]

--- a/tests/test_heads.py
+++ b/tests/test_heads.py
@@ -1,0 +1,56 @@
+import torch
+from torch.nn.functional import one_hot
+
+from causal_consistency_nn.model.heads import (
+    XgivenYZ,
+    XgivenYZConfig,
+    YgivenXZ,
+    YgivenXZConfig,
+    ZgivenXY,
+    ZgivenXYConfig,
+)
+
+
+def _make_onehot(y: torch.Tensor, num_classes: int) -> torch.Tensor:
+    return one_hot(y, num_classes=num_classes).float()
+
+
+def test_heads_shapes_and_gradients() -> None:
+    batch = 2
+    h_dim = 16
+    x_dim = 5
+    y_dim = 3
+    z_dim = 4
+
+    h = torch.randn(batch, h_dim, requires_grad=True)
+    y = torch.randint(0, y_dim, (batch,))
+    y_oh = _make_onehot(y, y_dim)
+    z = torch.randn(batch, z_dim)
+
+    z_head = ZgivenXY(ZgivenXYConfig(h_dim=h_dim, y_dim=y_dim, z_dim=z_dim))
+    y_head = YgivenXZ(YgivenXZConfig(h_dim=h_dim, z_dim=z_dim, y_dim=y_dim))
+    x_head = XgivenYZ(XgivenYZConfig(h_dim=h_dim, y_dim=y_dim, x_dim=x_dim))
+
+    dist_z = z_head(h, y_oh)
+    assert dist_z.mean.shape == (batch, z_dim)
+
+    dist_y = y_head(h, z)
+    assert dist_y.logits.shape == (batch, y_dim)
+
+    dist_x = x_head(h, y_oh)
+    assert dist_x.mean.shape == (batch, x_dim)
+
+    loss = (
+        dist_z.log_prob(z).sum()
+        + dist_y.log_prob(y).sum()
+        + dist_x.log_prob(torch.randn(batch, x_dim)).sum()
+    )
+    loss.backward()
+
+    for param in (
+        list(z_head.parameters())
+        + list(y_head.parameters())
+        + list(x_head.parameters())
+    ):
+        assert param.grad is not None
+        assert torch.isfinite(param.grad).all()


### PR DESCRIPTION
## Summary
- implement neural network heads with PyTorch distributions
- expose configuration dataclasses for head dimensions
- add unit tests covering distributions and gradient flow

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685298c2392c8324afec5d4363add3e9