### PR TITLE
Add loss utilities module

### DIFF
--- a/src/causal_consistency_nn/model/losses.py
+++ b/src/causal_consistency_nn/model/losses.py
@@ -1,0 +1,27 @@
+"""Loss utilities for causal consistency models."""
+
+from __future__ import annotations
+
+import torch
+from torch.distributions import Distribution, Normal, Categorical
+
+
+def nll_gaussian(dist: Distribution, target: torch.Tensor) -> torch.Tensor:
+    """Return the negative log likelihood under a Gaussian distribution."""
+    if not isinstance(dist, Normal):
+        raise TypeError("dist must be a Normal distribution")
+    return -dist.log_prob(target).mean()
+
+
+def cross_entropy(dist: Distribution, target: torch.Tensor) -> torch.Tensor:
+    """Return the cross entropy between a categorical distribution and target labels."""
+    if not isinstance(dist, Categorical):
+        raise TypeError("dist must be a Categorical distribution")
+    return -dist.log_prob(target).mean()
+
+
+def entropy_categorical(dist: Distribution) -> torch.Tensor:
+    """Return the entropy of a categorical distribution."""
+    if not isinstance(dist, Categorical):
+        raise TypeError("dist must be a Categorical distribution")
+    return dist.entropy().mean()

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,0 +1,31 @@
+import torch
+from torch.distributions import Normal, Categorical
+
+from causal_consistency_nn.model.losses import (
+    nll_gaussian,
+    cross_entropy,
+    entropy_categorical,
+)
+
+
+def test_nll_gaussian() -> None:
+    dist = Normal(torch.tensor(0.0), torch.tensor(1.0))
+    target = torch.tensor(0.0)
+    loss = nll_gaussian(dist, target)
+    expected = -dist.log_prob(target)
+    assert torch.isclose(loss, expected)
+
+
+def test_cross_entropy() -> None:
+    dist = Categorical(probs=torch.tensor([0.1, 0.9]))
+    target = torch.tensor(1)
+    loss = cross_entropy(dist, target)
+    expected = -dist.log_prob(target)
+    assert torch.isclose(loss, expected)
+
+
+def test_entropy_categorical() -> None:
+    dist = Categorical(probs=torch.tensor([0.1, 0.9]))
+    ent = entropy_categorical(dist)
+    expected = dist.entropy()
+    assert torch.isclose(ent, expected)


### PR DESCRIPTION
## Summary
- add `losses.py` with Gaussian NLL, cross entropy, and entropy helpers
- test the new loss functions

## Testing
- `ruff check src tests`
- `black src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685298c41f308324b2e151ed04a2ed53