### PR TITLE
Add semi-supervised EM loop

### DIFF
--- a/src/causal_consistency_nn/model/__init__.py
+++ b/src/causal_consistency_nn/model/__init__.py
@@ -1,0 +1,14 @@
+"""Model components."""
+
+from .backbone import build_backbone
+from .heads import x_given_yz, y_given_xz, z_given_xy
+from .semi_loop import EMConfig, train_em
+
+__all__ = [
+    "build_backbone",
+    "x_given_yz",
+    "y_given_xz",
+    "z_given_xy",
+    "EMConfig",
+    "train_em",
+]

--- a/src/causal_consistency_nn/model/semi_loop.py
+++ b/src/causal_consistency_nn/model/semi_loop.py
@@ -1,0 +1,90 @@
+"""Semi-supervised EM training loop."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Tuple
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+
+@dataclass
+class EMConfig:
+    """Configuration for EM training."""
+
+    lambda1: float = 1.0
+    lambda2: float = 1.0
+    lambda3: float = 1.0
+    beta: float = 1.0
+    tau: float = 1.0
+    lr: float = 1e-3
+    epochs: int = 10
+    pretrain_epochs: int = 0
+
+
+def _supervised_step(
+    model: nn.Module,
+    batch: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    config: EMConfig,
+    mse: nn.Module,
+    ce: nn.Module,
+) -> torch.Tensor:
+    x, y, z = batch
+    z_pred = model.head_z_given_xy(x, y)
+    y_logits = model.head_y_given_xz(x, z)
+    x_pred = model.head_x_given_yz(y, z)
+
+    loss_z = mse(z_pred, z)
+    loss_y = ce(y_logits, y)
+    loss_x = mse(x_pred, x)
+    loss = config.lambda1 * loss_z + config.lambda2 * loss_y + config.lambda3 * loss_x
+    return loss
+
+
+def _unsupervised_step(
+    model: nn.Module,
+    batch: Tuple[torch.Tensor, torch.Tensor],
+    config: EMConfig,
+    mse: nn.Module,
+) -> torch.Tensor:
+    x, z = batch
+    y_logits = model.head_y_given_xz(x, z)
+    y_probs = F.softmax(y_logits / config.tau, dim=-1)
+    y_pseudo = torch.argmax(y_probs, dim=-1)
+    z_pred = model.head_z_given_xy(x, y_pseudo)
+    x_pred = model.head_x_given_yz(y_pseudo, z)
+    loss_z = mse(z_pred, z)
+    loss_x = mse(x_pred, x)
+    loss = config.beta * (config.lambda1 * loss_z + config.lambda3 * loss_x)
+    return loss
+
+
+def train_em(
+    model: nn.Module,
+    supervised_loader: Iterable[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+    unsupervised_loader: Optional[Iterable[Tuple[torch.Tensor, torch.Tensor]]],
+    config: Optional[EMConfig] = None,
+) -> None:
+    """Train ``model`` using a simple EM loop."""
+    if config is None:
+        config = EMConfig()
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=config.lr)
+    mse = nn.MSELoss()
+    ce = nn.CrossEntropyLoss()
+
+    for epoch in range(config.epochs):
+        for batch in supervised_loader:
+            optimizer.zero_grad()
+            loss = _supervised_step(model, batch, config, mse, ce)
+            loss.backward()
+            optimizer.step()
+
+        if unsupervised_loader is not None and epoch >= config.pretrain_epochs:
+            for batch in unsupervised_loader:
+                optimizer.zero_grad()
+                loss = _unsupervised_step(model, batch, config, mse)
+                loss.backward()
+                optimizer.step()

--- a/tests/test_semi_loop.py
+++ b/tests/test_semi_loop.py
@@ -1,0 +1,61 @@
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from causal_consistency_nn.model.semi_loop import EMConfig, train_em
+
+
+class DummyModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc_z = nn.Linear(2, 1)
+        self.fc_y = nn.Linear(2, 2)
+        self.fc_x = nn.Linear(2, 1)
+
+    def head_z_given_xy(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        y = y.float().unsqueeze(-1)
+        return self.fc_z(torch.cat([x, y], dim=1))
+
+    def head_y_given_xz(self, x: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
+        return self.fc_y(torch.cat([x, z], dim=1))
+
+    def head_x_given_yz(self, y: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
+        y = y.float().unsqueeze(-1)
+        return self.fc_x(torch.cat([y, z], dim=1))
+
+
+def create_data(n: int = 20) -> tuple[DataLoader, DataLoader]:
+    x = torch.randn(n, 1)
+    y = (x.squeeze() > 0).long()
+    z = x + y.float().unsqueeze(-1)
+
+    sup_ds = TensorDataset(x, y, z)
+    unsup_ds = TensorDataset(x, z)
+    sup_loader = DataLoader(sup_ds, batch_size=5)
+    unsup_loader = DataLoader(unsup_ds, batch_size=5)
+    return sup_loader, unsup_loader
+
+
+def test_train_em_reduces_loss() -> None:
+    sup_loader, unsup_loader = create_data()
+    model = DummyModel()
+    config = EMConfig(epochs=3, pretrain_epochs=1, lr=0.01)
+
+    mse = nn.MSELoss()
+    ce = nn.CrossEntropyLoss()
+
+    def eval_loss() -> float:
+        total = 0.0
+        for batch in sup_loader:
+            x, y, z = batch
+            z_pred = model.head_z_given_xy(x, y)
+            y_logits = model.head_y_given_xz(x, z)
+            x_pred = model.head_x_given_yz(y, z)
+            loss = mse(z_pred, z) + ce(y_logits, y) + mse(x_pred, x)
+            total += loss.item()
+        return total
+
+    loss_before = eval_loss()
+    train_em(model, sup_loader, unsup_loader, config)
+    loss_after = eval_loss()
+    assert loss_after < loss_before


### PR DESCRIPTION
## Summary
- add EMConfig dataclass and train_em routine for semi-supervised training
- expose training utilities via package __init__
- test training loop on a small synthetic task

## Testing
- `python -m black .`
- `python -m ruff check --fix .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685298c5ab0483249f958bd68d47cc45