### PR TITLE
Update docs for config overview

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,22 @@
 # Documentation
+
+This project implements the causal-consistency neural network described in `Prompt.txt`. The codebase now exposes a YAML-based configuration system and a modular set of model components.
+
+## Configuration system
+Configuration files live in the `configs/` directory and are parsed with `pydantic` dataclasses. All hyperparameters, such as backbone size or loss weights, can be changed in the YAML file or overridden via CLI flags:
+
+```bash
+python src/train.py --config configs/train_synth.yaml optimizer.lr=1e-3
+```
+
+## Model components
+The network is composed of a shared `Backbone` and three heads:
+
+- `ZgivenXY` predicts post-treatment variables `Z` from `X` and `Y`.
+- `YgivenXZ` estimates missing treatments from `X` and `Z`.
+- `XgivenYZ` reconstructs `X` given `Y` and `Z`.
+
+These modules can be swapped or extended through the configuration system.
+
+## Training loop
+`train.py` runs a semi-supervised training loop that mixes supervised losses with an unsupervised term for rows missing `Y`. Parameters are updated with gradient descent and each run saves its checkpoint together with the YAML config for full reproducibility.

--- a/examples/scripts/train_config.yaml
+++ b/examples/scripts/train_config.yaml
@@ -1,0 +1,5 @@
+# Example configuration for training on synthetic data
+model:
+  hidden_dim: 32
+training:
+  epochs: 10

--- a/examples/scripts/train_synth.sh
+++ b/examples/scripts/train_synth.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
-poetry run python src/train.py
+# Example training invocation using a YAML configuration file
+CONFIG_FILE=${1:-examples/scripts/train_config.yaml}
+poetry run python src/train.py --config "$CONFIG_FILE"


### PR DESCRIPTION
## Summary
- document configuration system, model components and training loop
- show using a YAML config in `train_synth.sh`
- add example YAML config

## Testing
- `black . --exclude docs --check`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685298ca10088324a603367ecfea2b66