### PR TITLE
Improve docs and example notebook

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,5 +18,34 @@ The network is composed of a shared `Backbone` and three heads:
 
 These modules can be swapped or extended through the configuration system.
 
-## Training loop
-`train.py` runs a semi-supervised training loop that mixes supervised losses with an unsupervised term for rows missing `Y`. Parameters are updated with gradient descent and each run saves its checkpoint together with the YAML config for full reproducibility.
+## Data generation
+Synthetic datasets following the $X \to Y \to Z$ structure can be generated with
+`examples/scripts/generate_synth.py`. The script outputs a small CSV file that is
+used throughout the examples and tests.
+
+## Training workflow
+`train.py` launches a semi-supervised training loop that mixes supervised losses
+with an unsupervised term for rows missing `Y`. A run is configured via a YAML
+file and optional CLI overrides:
+
+```bash
+python src/train.py --config examples/scripts/train_config.yaml --model-hidden-dim 16
+```
+
+Each run stores its checkpoint alongside the resolved configuration for full
+reproducibility.
+
+## Configuration reference
+The configuration is split into three dataclasses:
+
+- **ModelConfig** – `hidden_dim`, `num_layers`.
+- **LossWeights** – `z_yx`, `y_xz`, `x_yz`, `unsup`.
+- **TrainingConfig** – `batch_size`, `epochs`, `learning_rate`, `device`.
+
+Fields may be overridden on the command line using flags such as
+`--model-hidden-dim` or via environment variables like `MODEL__NUM_LAYERS=4`.
+
+## Evaluation
+After training, run `src/eval.py` to compute metrics on the saved checkpoint.
+The current implementation simply prints a placeholder message but forms the
+entry point for future evaluation utilities.

--- a/examples/notebook_intro.ipynb
+++ b/examples/notebook_intro.ipynb
@@ -1,1 +1,45 @@
-{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Minimal training demo\n",
+    "This notebook runs the example training script using a small configuration and then calls the evaluation entry point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from causal_consistency_nn import train\n",
+    "train.main([\"--config\", \"examples/scripts/train_config.yaml\", \"--model-hidden-dim\", \"16\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from causal_consistency_nn import eval\n",
+    "eval.main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- expand docs with data generation, training and evaluation sections
- document config fields and CLI overrides
- update the introductory notebook with a minimal training+evaluation demo

## Testing
- `black src tests examples/scripts/*.py`
- `ruff check src tests examples/scripts/*.py`
- `pytest -q` *(fails: ImportError: cannot import name 'build_backbone')*

------
https://chatgpt.com/codex/tasks/task_e_6852aa0a02c4832481f32e864cd9d3e5