### PR TITLE
Add synthetic data utilities

### DIFF
--- a/examples/scripts/generate_synth.py
+++ b/examples/scripts/generate_synth.py
@@ -1,1 +1,34 @@
-print("Generate synthetic data placeholder")
+"""Generate and save a synthetic dataset."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import torch
+
+from causal_consistency_nn.config import SyntheticDataConfig
+from causal_consistency_nn.data import generate_synthetic
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate synthetic data")
+    parser.add_argument("--out", type=Path, default=Path("synthetic.pt"))
+    parser.add_argument("--n-samples", type=int, default=1000)
+    parser.add_argument("--noise-std", type=float, default=0.1)
+    parser.add_argument("--missing-y-prob", type=float, default=0.0)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    cfg = SyntheticDataConfig(
+        n_samples=args.n_samples,
+        noise_std=args.noise_std,
+        missing_y_prob=args.missing_y_prob,
+    )
+    ds = generate_synthetic(cfg, seed=args.seed)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(ds.tensors, args.out)
+    print(f"Saved dataset to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/causal_consistency_nn/config.py
+++ b/src/causal_consistency_nn/config.py
@@ -38,12 +38,22 @@ class TrainingConfig:
     device: str = "cpu"
 
 
+@dataclass
+class SyntheticDataConfig:
+    """Parameters controlling synthetic data generation."""
+
+    n_samples: int = 1000
+    noise_std: float = 0.1
+    missing_y_prob: float = 0.0
+
+
 class Settings(BaseSettings):
     """Global configuration loaded from environment variables or a YAML file."""
 
     model: ModelConfig = Field(default_factory=ModelConfig)
     loss: LossWeights = Field(default_factory=LossWeights)
     train: TrainingConfig = Field(default_factory=TrainingConfig)
+    data: SyntheticDataConfig = Field(default_factory=SyntheticDataConfig)
     config_path: str | None = None
 
     model_config = SettingsConfigDict(env_nested_delimiter="__")
@@ -59,6 +69,7 @@ class Settings(BaseSettings):
             "model": ModelConfig,
             "loss": LossWeights,
             "train": TrainingConfig,
+            "data": SyntheticDataConfig,
         }
         for section, dc in env_map.items():
             if section in data:

--- a/src/causal_consistency_nn/data/__init__.py
+++ b/src/causal_consistency_nn/data/__init__.py
@@ -1,0 +1,6 @@
+"""Data loading utilities."""
+
+from .dummy import load_dummy
+from .synthetic import generate_synthetic, get_synth_dataloaders
+
+__all__ = ["load_dummy", "generate_synthetic", "get_synth_dataloaders"]

--- a/src/causal_consistency_nn/data/synthetic.py
+++ b/src/causal_consistency_nn/data/synthetic.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from ..config import SyntheticDataConfig
+
+
+def generate_synthetic(
+    cfg: SyntheticDataConfig, seed: int | None = None
+) -> TensorDataset:
+    """Generate a synthetic dataset following a simple SCM.
+
+    X ~ N(0,1)
+    Y | X ~ Bernoulli(sigmoid(X))
+    Z | X,Y = X + Y + eps,  eps ~ N(0, noise_std)
+
+    Missingness in Y is governed by ``cfg.missing_y_prob``.
+    """
+    g = torch.Generator()
+    if seed is not None:
+        g.manual_seed(seed)
+
+    x = torch.randn(cfg.n_samples, 1, generator=g)
+    probs = torch.sigmoid(x.squeeze())
+    y = torch.bernoulli(probs, generator=g).long()
+    noise = torch.randn(cfg.n_samples, 1, generator=g) * cfg.noise_std
+    z = x + y.float().unsqueeze(-1) + noise
+
+    mask = torch.rand(cfg.n_samples, generator=g) > cfg.missing_y_prob
+    mask = mask.to(torch.bool)
+
+    return TensorDataset(x, y, z, mask)
+
+
+def get_synth_dataloaders(
+    cfg: SyntheticDataConfig, batch_size: int, seed: int | None = None
+) -> Tuple[DataLoader, DataLoader]:
+    """Return supervised and unsupervised dataloaders."""
+    dataset = generate_synthetic(cfg, seed)
+    x, y, z, mask = dataset.tensors
+
+    sup_ds = TensorDataset(x[mask], y[mask], z[mask])
+    unsup_ds = TensorDataset(x[~mask], z[~mask])
+
+    sup_loader = DataLoader(sup_ds, batch_size=batch_size, shuffle=True)
+    unsup_loader = DataLoader(unsup_ds, batch_size=batch_size, shuffle=True)
+    return sup_loader, unsup_loader
+
+
+__all__ = ["generate_synthetic", "get_synth_dataloaders"]

--- a/src/causal_consistency_nn/model/__init__.py
+++ b/src/causal_consistency_nn/model/__init__.py
@@ -1,14 +1,25 @@
-"""Model components."""
+"""Public model API."""
 
-from .backbone import build_backbone
-from .heads import x_given_yz, y_given_xz, z_given_xy
+from .backbone import Backbone, BackboneConfig
+from .heads import (
+    XgivenYZ,
+    XgivenYZConfig,
+    YgivenXZ,
+    YgivenXZConfig,
+    ZgivenXY,
+    ZgivenXYConfig,
+)
 from .semi_loop import EMConfig, train_em
 
 __all__ = [
-    "build_backbone",
-    "x_given_yz",
-    "y_given_xz",
-    "z_given_xy",
+    "Backbone",
+    "BackboneConfig",
+    "ZgivenXY",
+    "ZgivenXYConfig",
+    "YgivenXZ",
+    "YgivenXZConfig",
+    "XgivenYZ",
+    "XgivenYZConfig",
     "EMConfig",
     "train_em",
 ]

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import torch
+
+from causal_consistency_nn.config import SyntheticDataConfig
+from causal_consistency_nn.data.synthetic import (
+    generate_synthetic,
+    get_synth_dataloaders,
+)
+
+
+def test_generate_synthetic_shapes() -> None:
+    cfg = SyntheticDataConfig(n_samples=10, noise_std=0.1, missing_y_prob=0.2)
+    ds = generate_synthetic(cfg, seed=0)
+    x, y, z, m = ds.tensors
+    assert x.shape == (10, 1)
+    assert y.shape == (10,)
+    assert z.shape == (10, 1)
+    assert m.shape == (10,)
+
+
+def test_generate_synthetic_reproducible() -> None:
+    cfg = SyntheticDataConfig(n_samples=5, noise_std=0.0, missing_y_prob=0.0)
+    ds1 = generate_synthetic(cfg, seed=42)
+    ds2 = generate_synthetic(cfg, seed=42)
+    for t1, t2 in zip(ds1.tensors, ds2.tensors):
+        assert torch.equal(t1, t2)
+
+
+def test_get_synth_dataloaders() -> None:
+    cfg = SyntheticDataConfig(n_samples=20, noise_std=0.1, missing_y_prob=0.5)
+    sup, unsup = get_synth_dataloaders(cfg, batch_size=4, seed=0)
+    bx = next(iter(sup))
+    assert len(bx) == 3
+    bx_uns = next(iter(unsup))
+    assert len(bx_uns) == 2


### PR DESCRIPTION
## Summary
- implement synthetic dataset generation and dataloaders
- expose new utilities and configs
- update example script to generate datasets
- add unit tests for synthetic data
- fix model `__init__`

## Testing
- `ruff check --fix .`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853264dbc208324af142f78a861b6d3