### PR TITLE
Add end-to-end training pipeline

### DIFF
--- a/examples/scripts/train_synth.sh
+++ b/examples/scripts/train_synth.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 # Example training invocation using a YAML configuration file
 CONFIG_FILE=${1:-examples/scripts/train_config.yaml}
-poetry run python src/train.py --config "$CONFIG_FILE"
+OUT_DIR=${2:-examples/scripts/out}
+poetry run python -m causal_consistency_nn.train \
+  --config "$CONFIG_FILE" \
+  --output-dir "$OUT_DIR"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ packages = [{include = "causal_consistency_nn", from = "src"}]
 python = "^3.10"
 torch = "2.7.1"
 pyro-ppl = "1.9.1"
+pydantic = "^2.7"
+pydantic-settings = "^2.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4"

--- a/src/causal_consistency_nn/data/__init__.py
+++ b/src/causal_consistency_nn/data/__init__.py
@@ -1,0 +1,6 @@
+"""Data loading utilities."""
+
+from .dummy import load_dummy
+from .synthetic import SynthConfig, make_synthetic_loaders
+
+__all__ = ["load_dummy", "SynthConfig", "make_synthetic_loaders"]

--- a/src/causal_consistency_nn/data/synthetic.py
+++ b/src/causal_consistency_nn/data/synthetic.py
@@ -1,0 +1,34 @@
+"""Synthetic dataset utilities for integration tests and examples."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+
+@dataclass
+class SynthConfig:
+    """Configuration for :func:`make_synthetic_loaders`."""
+
+    n: int = 100
+    batch_size: int = 32
+
+
+def make_synthetic_loaders(
+    cfg: SynthConfig | None = None,
+) -> tuple[DataLoader, DataLoader]:
+    """Return supervised and unsupervised loaders for a toy SCM."""
+    if cfg is None:
+        cfg = SynthConfig()
+
+    x = torch.randn(cfg.n, 1)
+    y = (x.squeeze() > 0).long()
+    z = x + y.float().unsqueeze(-1)
+
+    sup_ds = TensorDataset(x, y, z)
+    unsup_ds = TensorDataset(x, z)
+    sup_loader = DataLoader(sup_ds, batch_size=cfg.batch_size)
+    unsup_loader = DataLoader(unsup_ds, batch_size=cfg.batch_size)
+    return sup_loader, unsup_loader

--- a/src/causal_consistency_nn/model/__init__.py
+++ b/src/causal_consistency_nn/model/__init__.py
@@ -1,14 +1,27 @@
-"""Model components."""
+"""Model components for causal-consistency networks."""
 
-from .backbone import build_backbone
-from .heads import x_given_yz, y_given_xz, z_given_xy
+from .backbone import Backbone, BackboneConfig
+from .causal_model import CausalModel
+from .heads import (
+    XgivenYZ,
+    XgivenYZConfig,
+    YgivenXZ,
+    YgivenXZConfig,
+    ZgivenXY,
+    ZgivenXYConfig,
+)
 from .semi_loop import EMConfig, train_em
 
 __all__ = [
-    "build_backbone",
-    "x_given_yz",
-    "y_given_xz",
-    "z_given_xy",
+    "Backbone",
+    "BackboneConfig",
+    "CausalModel",
+    "XgivenYZ",
+    "XgivenYZConfig",
+    "YgivenXZ",
+    "YgivenXZConfig",
+    "ZgivenXY",
+    "ZgivenXYConfig",
     "EMConfig",
     "train_em",
 ]

--- a/src/causal_consistency_nn/model/causal_model.py
+++ b/src/causal_consistency_nn/model/causal_model.py
@@ -1,0 +1,43 @@
+"""Simple model combining the backbone and conditional heads."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn.functional import one_hot
+
+from .backbone import Backbone
+from .heads import XgivenYZ, YgivenXZ, ZgivenXY
+
+
+class CausalModel(nn.Module):
+    """Neural network enforcing causal consistency."""
+
+    def __init__(
+        self,
+        backbone: Backbone,
+        head_z: ZgivenXY,
+        head_y: YgivenXZ,
+        head_x: XgivenYZ,
+        y_dim: int,
+    ) -> None:
+        super().__init__()
+        self.backbone = backbone
+        self.head_z = head_z
+        self.head_y = head_y
+        self.head_x = head_x
+        self.y_dim = y_dim
+
+    def head_z_given_xy(self, x: torch.Tensor, y: torch.Tensor):
+        h = self.backbone(x)
+        y_oh = one_hot(y, num_classes=self.y_dim).float()
+        return self.head_z(h, y_oh).mean
+
+    def head_y_given_xz(self, x: torch.Tensor, z: torch.Tensor):
+        h = self.backbone(x)
+        return self.head_y(h, z).logits
+
+    def head_x_given_yz(self, y: torch.Tensor, z: torch.Tensor):
+        h = self.backbone(z)
+        y_oh = one_hot(y, num_classes=self.y_dim).float()
+        return self.head_x(h, y_oh).mean

--- a/tests/test_train_end_to_end.py
+++ b/tests/test_train_end_to_end.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from torch import nn
+
+from causal_consistency_nn.config import Settings
+from causal_consistency_nn.data import SynthConfig, make_synthetic_loaders
+from causal_consistency_nn.train import run_training
+
+
+def test_end_to_end_training(tmp_path) -> None:
+    settings = Settings()
+    settings.train.batch_size = 5
+    settings.train.learning_rate = 0.01
+
+    sup_loader, _ = make_synthetic_loaders(SynthConfig(n=40, batch_size=5))
+
+    def eval_loss(model) -> float:
+        mse = nn.MSELoss()
+        ce = nn.CrossEntropyLoss()
+        total = 0.0
+        for x, y, z in sup_loader:
+            z_pred = model.head_z_given_xy(x, y)
+            y_logits = model.head_y_given_xz(x, z)
+            x_pred = model.head_x_given_yz(y, z)
+            loss = mse(z_pred, z) + ce(y_logits, y) + mse(x_pred, x)
+            total += loss.item()
+        return total
+
+    settings.train.epochs = 0
+    model_before = run_training(settings, tmp_path / "before")
+    loss_before = eval_loss(model_before)
+
+    settings.train.epochs = 3
+    model_after = run_training(settings, tmp_path / "after")
+    loss_after = eval_loss(model_after)
+
+    assert loss_after < loss_before


### PR DESCRIPTION
## Summary
- build a simple `CausalModel` and synthetic data utilities
- flesh out `train.py` to instantiate the model, load data, run EM training and save artefacts
- update example training script to use the new entry point
- include an end-to-end test exercising the training loop
- add missing pydantic dependencies

## Testing
- `ruff check .`
- `black -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853266e03e083248784edc66acdb6cc