### PR TITLE
Implement metrics and serving API

### DIFF
--- a/src/causal_consistency_nn/eval.py
+++ b/src/causal_consistency_nn/eval.py
@@ -1,8 +1,56 @@
-"""Evaluation entry point."""
+"""Simple evaluation CLI computing causal metrics."""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+
+from .metrics import average_treatment_effect, log_likelihood
+from .serve import predict_z
 
 
-def main() -> None:
-    print("Evaluation placeholder")
+def _create_synth(
+    n: int = 100, noise: float = 0.1
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    x = torch.randn(n, 1)
+    y = (x.squeeze() > 0).long()
+    z = x + y.float().unsqueeze(-1) + torch.randn_like(x) * noise
+    return x, y, z
+
+
+class _OracleModel:
+    def __init__(self, noise: float = 0.1) -> None:
+        self.noise = noise
+
+    def head_z_given_xy(
+        self, x: torch.Tensor, y: torch.Tensor
+    ) -> torch.distributions.Normal:
+        mu = x + y.float().unsqueeze(-1)
+        sigma = torch.full_like(mu, self.noise)
+        return torch.distributions.Normal(mu, sigma)
+
+    def head_y_given_xz(
+        self, x: torch.Tensor, z: torch.Tensor
+    ) -> torch.distributions.Categorical:
+        logits = (
+            torch.stack([-(z - x).squeeze(), (z - x).squeeze()], dim=-1) / self.noise
+        )
+        return torch.distributions.Categorical(logits=logits)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Evaluation script")
+    parser.parse_args(argv)
+
+    x, y, z = _create_synth()
+    model = _OracleModel()
+
+    ate_val = average_treatment_effect(model, x)
+    ll = log_likelihood(model.head_z_given_xy(x, y), z)
+
+    preds = predict_z(model, x, y)
+    print(f"ATE: {ate_val:.3f}, loglik_z: {ll:.3f}, pred_shape: {preds.shape}")
 
 
 if __name__ == "__main__":

--- a/src/causal_consistency_nn/metrics.py
+++ b/src/causal_consistency_nn/metrics.py
@@ -1,0 +1,32 @@
+"""Causal evaluation metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from torch import Tensor
+from torch.distributions import Distribution
+
+
+def average_treatment_effect(
+    model: Any, x: Tensor, treatment0: int | Tensor = 0, treatment1: int | Tensor = 1
+) -> Tensor:
+    """Estimate the Average Treatment Effect via the ``Z|X,Y`` head."""
+    if isinstance(treatment0, int):
+        y0 = torch.full((x.size(0),), treatment0, dtype=torch.long, device=x.device)
+    else:
+        y0 = treatment0
+    if isinstance(treatment1, int):
+        y1 = torch.full((x.size(0),), treatment1, dtype=torch.long, device=x.device)
+    else:
+        y1 = treatment1
+
+    dist0 = model.head_z_given_xy(x, y0)
+    dist1 = model.head_z_given_xy(x, y1)
+    return (dist1.mean - dist0.mean).mean()
+
+
+def log_likelihood(dist: Distribution, target: Tensor) -> Tensor:
+    """Return the mean log likelihood under ``dist``."""
+    return dist.log_prob(target).mean()

--- a/src/causal_consistency_nn/model/__init__.py
+++ b/src/causal_consistency_nn/model/__init__.py
@@ -1,14 +1,32 @@
-"""Model components."""
+"""Public model components."""
 
-from .backbone import build_backbone
-from .heads import x_given_yz, y_given_xz, z_given_xy
+from __future__ import annotations
+
+from .backbone import Backbone, BackboneConfig
+from .heads import (
+    XgivenYZ,
+    XgivenYZConfig,
+    YgivenXZ,
+    YgivenXZConfig,
+    ZgivenXY,
+    ZgivenXYConfig,
+)
 from .semi_loop import EMConfig, train_em
 
 __all__ = [
-    "build_backbone",
-    "x_given_yz",
-    "y_given_xz",
-    "z_given_xy",
+    "Backbone",
+    "BackboneConfig",
+    "ZgivenXY",
+    "ZgivenXYConfig",
+    "YgivenXZ",
+    "YgivenXZConfig",
+    "XgivenYZ",
+    "XgivenYZConfig",
     "EMConfig",
     "train_em",
 ]
+
+
+def build_backbone(config: BackboneConfig) -> Backbone:
+    """Convenience wrapper returning a :class:`Backbone`."""
+    return Backbone(config)

--- a/src/causal_consistency_nn/serve.py
+++ b/src/causal_consistency_nn/serve.py
@@ -1,0 +1,25 @@
+"""Lightweight inference helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from torch import Tensor
+
+
+def predict_z(model: Any, x: Tensor, y: Tensor) -> Tensor:
+    """Return the mean of ``Z | X=x, Y=y``."""
+    dist = model.head_z_given_xy(x, y)
+    return dist.mean
+
+
+def counterfactual_z(model: Any, x: Tensor, y_prime: Tensor) -> Tensor:
+    """Estimate counterfactual ``Z`` for a different treatment ``y_prime``."""
+    dist = model.head_z_given_xy(x, y_prime)
+    return dist.mean
+
+
+def impute_y(model: Any, x: Tensor, z: Tensor) -> Tensor:
+    """Return posterior probabilities ``p(Y | X=x, Z=z)``."""
+    dist = model.head_y_given_xz(x, z)
+    return dist.probs

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,49 @@
+import torch
+from torch import nn
+
+from causal_consistency_nn.metrics import average_treatment_effect, log_likelihood
+from causal_consistency_nn.serve import predict_z, counterfactual_z, impute_y
+
+
+def _create_synth(n: int = 50, noise: float = 0.1):
+    x = torch.randn(n, 1)
+    y = (x.squeeze() > 0).long()
+    z = x + y.float().unsqueeze(-1) + torch.randn_like(x) * noise
+    return x, y, z
+
+
+class OracleModel(nn.Module):
+    def __init__(self, noise: float = 0.1) -> None:
+        super().__init__()
+        self.noise = noise
+
+    def head_z_given_xy(self, x: torch.Tensor, y: torch.Tensor):
+        mu = x + y.float().unsqueeze(-1)
+        sigma = torch.full_like(mu, self.noise)
+        return torch.distributions.Normal(mu, sigma)
+
+    def head_y_given_xz(self, x: torch.Tensor, z: torch.Tensor):
+        logits = (
+            torch.stack([-(z - x).squeeze(), (z - x).squeeze()], dim=-1) / self.noise
+        )
+        return torch.distributions.Categorical(logits=logits)
+
+
+class TestMetrics:
+    def test_ate_and_ll(self) -> None:
+        x, y, z = _create_synth()
+        model = OracleModel()
+        ate_val = average_treatment_effect(model, x)
+        assert torch.isclose(ate_val, torch.tensor(1.0), atol=0.1)
+        ll = log_likelihood(model.head_z_given_xy(x, y), z)
+        assert ll > -1.0
+
+    def test_serving_helpers(self) -> None:
+        x, y, z = _create_synth(n=10)
+        model = OracleModel()
+        preds = predict_z(model, x, y)
+        assert preds.shape == z.shape
+        cf = counterfactual_z(model, x, 1 - y)
+        assert cf.shape == z.shape
+        probs = impute_y(model, x, z)
+        assert probs.shape == (x.size(0), 2)


### PR DESCRIPTION
## Summary
- implement `metrics.py` with average treatment effect and log-likelihood utilities
- expand `eval.py` to demonstrate metric computation
- fix model exports and add a `build_backbone` helper
- provide inference helpers in `serve.py`
- add integration tests for metrics and serving helpers

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853268196d883249ecbe99e7fd8426b