### PR TITLE
Add coverage gate to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black ruff pytest
+          pip install black ruff pytest pytest-cov
       - name: Run formatters
         run: |
           black .
@@ -36,4 +36,7 @@ jobs:
             git push
           fi
       - name: Run tests
-        run: pytest -s
+        run: |
+          pytest --cov=src --cov=tests --cov-report=term --cov-report=xml \
+            --cov-fail-under=90 -s
+

--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ poetry run python src/train.py
 ```
 
 The model enforces the factorisation $X \to Y \to Z$ by sharing a backbone encoder and three output heads. See the documentation in `docs/` for details.
+
+## Running tests
+
+Use `pytest` together with `pytest-cov` to measure coverage locally. Coverage must remain above 90 %:
+
+```bash
+pip install -e . pytest pytest-cov
+pytest --cov=src --cov=tests --cov-report=term --cov-fail-under=90
+```


### PR DESCRIPTION
## Summary
- collect coverage in CI with pytest-cov
- require >=90% coverage in CI
- document how to run tests with coverage locally

## Testing
- `black .`
- `ruff check --fix .`
- `pytest` *(fails: cannot import name 'build_backbone')*

------
https://chatgpt.com/codex/tasks/task_e_68532698f2908324895bdf07ed59fe6b