### PR TITLE
Add metrics and serving utilities

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,19 @@ Fields may be overridden on the command line using flags such as
 `--model-hidden-dim` or via environment variables like `MODEL__NUM_LAYERS=4`.
 
 ## Evaluation
-After training, run `src/eval.py` to compute metrics on the saved checkpoint.
-The current implementation simply prints a placeholder message but forms the
-entry point for future evaluation utilities.
+`eval.py` loads a saved model and reports causal metrics. The script currently
+computes the average treatment effect (ATE) by drawing counterfactual `Z`
+predictions for both treatment arms and compares them. It also returns the
+average log likelihood of observed `Z` values under the model.
+
+```bash
+python src/eval.py --config configs/train_synth.yaml --model-path run/model.pt
+```
+
+The `metrics.py` module exposes reusable helpers for ATE and log-likelihood
+calculations.
+
+## Serving
+`serve.py` provides a minimal API for inference with a trained model. Functions
+`predict_z`, `counterfactual_z` and `impute_y` wrap the network's heads for
+easy integration in production services.

--- a/src/causal_consistency_nn/eval.py
+++ b/src/causal_consistency_nn/eval.py
@@ -1,8 +1,64 @@
-"""Evaluation entry point."""
+"""Evaluation utilities computing causal metrics."""
+
+from __future__ import annotations
 
 
-def main() -> None:
-    print("Evaluation placeholder")
+from pathlib import Path
+import argparse
+import yaml
+import torch
+
+from .config import Settings
+from .data import get_synth_dataloaders
+from .train import ConsistencyModel
+from .metrics import dataset_log_likelihood
+
+
+def load_model(model_path: Path, settings: Settings) -> ConsistencyModel:
+    """Load ``ConsistencyModel`` from ``model_path``."""
+    sup_loader, _ = get_synth_dataloaders(
+        settings.data, batch_size=settings.train.batch_size, seed=0
+    )
+    x_ex, y_ex, z_ex = next(iter(sup_loader))
+    model = ConsistencyModel(
+        x_ex.shape[1], int(y_ex.max().item()) + 1, z_ex.shape[1], settings.model
+    )
+    state = torch.load(model_path, map_location=settings.train.device)
+    model.load_state_dict(state)
+    model.eval()
+    return model
+
+
+def evaluate(model: ConsistencyModel, loader) -> dict[str, float]:
+    """Return log likelihood and ATE estimates for ``model`` on ``loader``."""
+    ll = dataset_log_likelihood(model, loader)
+    xs: list[torch.Tensor] = []
+    for batch in loader:
+        xs.append(batch[0])
+    x_all = torch.cat(xs)
+    with torch.no_grad():
+        z_treat = model.head_z_given_xy(x_all, torch.ones(len(x_all), dtype=torch.long))
+        z_control = model.head_z_given_xy(
+            x_all, torch.zeros(len(x_all), dtype=torch.long)
+        )
+    ate = (z_treat.mean() - z_control.mean()).item()
+    return {"log_likelihood": ll, "ate": ate}
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI for evaluation on synthetic data."""
+    parser = argparse.ArgumentParser(description="Evaluation script")
+    parser.add_argument("--model-path", type=Path, required=True)
+    parser.add_argument("--config", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    settings = Settings.from_yaml(args.config)
+    sup_loader, _ = get_synth_dataloaders(
+        settings.data, batch_size=settings.train.batch_size, seed=0
+    )
+    model = load_model(args.model_path, settings)
+    metrics = evaluate(model, sup_loader)
+    print(yaml.safe_dump(metrics))
 
 
 if __name__ == "__main__":

--- a/src/causal_consistency_nn/metrics.py
+++ b/src/causal_consistency_nn/metrics.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import torch
+from torch import Tensor
+from torch.distributions import Normal
+import torch.nn.functional as F
+
+
+def average_treatment_effect(
+    y: Tensor, z: Tensor, treat: int = 1, control: int = 0
+) -> Tensor:
+    """Return the Average Treatment Effect from outcome samples."""
+    t_mask = y == treat
+    c_mask = y == control
+    if t_mask.sum() == 0 or c_mask.sum() == 0:
+        raise ValueError("both treatment groups must have at least one sample")
+    return z[t_mask].mean() - z[c_mask].mean()
+
+
+def log_likelihood_normal(mu: Tensor, sigma: Tensor, target: Tensor) -> Tensor:
+    """Compute mean log likelihood of a Normal distribution."""
+    dist = Normal(mu, sigma)
+    return dist.log_prob(target).mean()
+
+
+def dataset_log_likelihood(
+    model: torch.nn.Module,
+    loader: Iterable[tuple[Tensor, Tensor, Tensor]],
+) -> float:
+    """Average log likelihood of ``Z`` given ``X`` and ``Y`` for a dataset."""
+    total = 0.0
+    count = 0
+    for x, y, z in loader:
+        h = model.backbone(x)
+        y_oh = F.one_hot(y, num_classes=model.y_dim).float()
+        dist = model.head_z(h, y_oh)
+        total += dist.log_prob(z).sum().item()
+        count += z.numel()
+    return total / count
+
+
+__all__ = [
+    "average_treatment_effect",
+    "log_likelihood_normal",
+    "dataset_log_likelihood",
+]

--- a/src/causal_consistency_nn/serve.py
+++ b/src/causal_consistency_nn/serve.py
@@ -1,0 +1,35 @@
+"""Inference helpers for trained models."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+from .train import ConsistencyModel
+
+
+def predict_z(
+    model: ConsistencyModel, x: torch.Tensor, y: torch.Tensor
+) -> torch.Tensor:
+    """Return ``E[Z | X=x, Y=y]``."""
+    model.eval()
+    with torch.no_grad():
+        return model.head_z_given_xy(x, y)
+
+
+def counterfactual_z(
+    model: ConsistencyModel, x: torch.Tensor, y_prime: torch.Tensor
+) -> torch.Tensor:
+    """Estimate ``Z`` for counterfactual treatment ``y_prime``."""
+    return predict_z(model, x, y_prime)
+
+
+def impute_y(model: ConsistencyModel, x: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
+    """Return posterior probabilities of ``Y`` given ``X`` and ``Z``."""
+    model.eval()
+    with torch.no_grad():
+        logits = model.head_y_given_xz(x, z)
+        return F.softmax(logits, dim=-1)
+
+
+__all__ = ["predict_z", "counterfactual_z", "impute_y"]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import torch
+
+from causal_consistency_nn.metrics import (
+    average_treatment_effect,
+    log_likelihood_normal,
+)
+from causal_consistency_nn.config import SyntheticDataConfig
+from causal_consistency_nn.data.synthetic import generate_synthetic
+
+
+def test_average_treatment_effect_synth() -> None:
+    cfg = SyntheticDataConfig(n_samples=500, noise_std=0.1, missing_y_prob=0.0)
+    ds = generate_synthetic(cfg, seed=0)
+    x, _, _, _ = ds.tensors
+    z_treat = (x + 1).squeeze()
+    z_control = x.squeeze()
+    y_long = torch.cat(
+        [
+            torch.ones_like(z_treat, dtype=torch.long),
+            torch.zeros_like(z_control, dtype=torch.long),
+        ]
+    )
+    z_all = torch.cat([z_treat, z_control])
+    ate = average_treatment_effect(y_long, z_all)
+    assert torch.isclose(ate, torch.tensor(1.0), atol=1e-6)
+
+
+def test_log_likelihood_normal() -> None:
+    mu = torch.zeros(4, 1)
+    sigma = torch.ones(4, 1)
+    target = torch.randn(4, 1)
+    ll = log_likelihood_normal(mu, sigma, target)
+    expected = torch.distributions.Normal(mu, sigma).log_prob(target).mean()
+    assert torch.isclose(ll, expected)

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import torch
+
+from causal_consistency_nn import train
+from causal_consistency_nn.config import Settings
+from causal_consistency_nn.data import get_synth_dataloaders
+from causal_consistency_nn.serve import counterfactual_z, impute_y, predict_z
+
+
+def test_serving_helpers() -> None:
+    settings = Settings()
+    settings.train.epochs = 1
+    sup, unsup = get_synth_dataloaders(
+        settings.data, batch_size=settings.train.batch_size, seed=0
+    )
+    x_ex, y_ex, z_ex = next(iter(sup))
+    model = train.ConsistencyModel(
+        x_ex.shape[1], int(y_ex.max().item()) + 1, z_ex.shape[1], settings.model
+    )
+    train.train_em(model, sup, unsup, train.EMConfig(epochs=1))
+
+    pred = predict_z(model, x_ex, y_ex)
+    cf = counterfactual_z(model, x_ex, 1 - y_ex)
+    post = impute_y(model, x_ex, z_ex)
+
+    assert pred.shape == z_ex.shape
+    assert cf.shape == z_ex.shape
+    assert post.shape[0] == y_ex.shape[0]
+    assert torch.allclose(post.sum(-1), torch.ones_like(post[:, 0]), atol=1e-5)


### PR DESCRIPTION
## Summary
- implement `metrics.py` with ATE and log-likelihood helpers
- extend `eval.py` to load a model and compute causal metrics
- add `serve.py` exposing simple prediction helpers
- document evaluation and serving workflow
- test metrics functions and serving API

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853309b149883248776c4e60aa09a50