### PR TITLE
Add Docker assets and build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,7 @@ jobs:
         run: |
           pytest --cov=src --cov=tests --cov-report=term --cov-report=xml \
             --cov-fail-under=90 -s
+      - name: Build Docker image
+        run: |
+          docker build --build-arg DEVICE=${{ matrix.hardware }} -t causal-consistency:${{ matrix.hardware }} .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+# Build argument DEVICE chooses the base image (cpu or cuda)
+ARG DEVICE=cpu
+ARG PYTHON_VERSION=3.10
+ARG CUDA_IMAGE=nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+FROM python:${PYTHON_VERSION}-slim AS cpu
+# Install base packages for CPU image
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+FROM ${CUDA_IMAGE} AS cuda
+# Install Python on the CUDA image
+RUN apt-get update && apt-get install -y python3 python3-pip git \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/python3 /usr/local/bin/python \
+    && ln -s /usr/bin/pip3 /usr/local/bin/pip
+
+FROM ${DEVICE} AS final
+WORKDIR /app
+COPY pyproject.toml README.md LICENSE ./
+RUN pip install --no-cache-dir pip setuptools wheel
+RUN pip install --no-cache-dir .
+COPY src src
+COPY examples examples
+ENTRYPOINT ["python", "-m", "causal_consistency_nn"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -19,3 +19,29 @@ Use `pytest` together with `pytest-cov` to measure coverage locally. Coverage mu
 pip install -e . pytest pytest-cov
 pytest --cov=src --cov=tests --cov-report=term --cov-fail-under=90
 ```
+
+## Containerised workflow
+
+The project ships with a `Dockerfile` and `docker-compose.yml` to simplify
+training and serving. Build the CPU image and run a training job with:
+
+```bash
+docker compose build
+docker compose run train
+```
+
+To use a CUDA image set `DEVICE=cuda` before building:
+
+```bash
+DEVICE=cuda docker compose build
+DEVICE=cuda docker compose run train
+```
+
+A simple inference server can be launched with:
+
+```bash
+docker compose run --service-ports serve
+```
+
+The compose file mounts the repository in `/app` so outputs are written back to
+your local filesystem.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  train:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        DEVICE: ${DEVICE:-cpu}
+    volumes:
+      - .:/app
+    command: python -m causal_consistency_nn.train --config examples/scripts/train_config.yaml
+  serve:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        DEVICE: ${DEVICE:-cpu}
+    volumes:
+      - .:/app
+    command: python -m causal_consistency_nn.serve
+    ports:
+      - "8000:8000"

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,3 +62,18 @@ calculations.
 `serve.py` provides a minimal API for inference with a trained model. Functions
 `predict_z`, `counterfactual_z` and `impute_y` wrap the network's heads for
 easy integration in production services.
+
+## Docker workflow
+Both CPU and CUDA images can be built from the provided `Dockerfile`. Use
+`docker compose` to orchestrate common tasks:
+
+```bash
+docker compose build
+# Train using the current configuration
+docker compose run train
+
+# Launch the inference server
+docker compose run --service-ports serve
+```
+
+Set `DEVICE=cuda` when building if GPUs are available.

--- a/tests/test_cli_all_overrides.py
+++ b/tests/test_cli_all_overrides.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from causal_consistency_nn import train
+
+
+def test_cli_all_overrides(tmp_path: Path, capsys) -> None:
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("model:\n  hidden_dim: 8\n  num_layers: 1\n")
+    train.main(
+        [
+            "--config",
+            str(cfg),
+            "--model-hidden-dim",
+            "16",
+            "--model-num-layers",
+            "2",
+            "--loss-z-yx",
+            "0.5",
+            "--loss-y-xz",
+            "0.5",
+            "--loss-x-yz",
+            "0.5",
+            "--loss-unsup",
+            "0.2",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert "hidden_dim=16" in out
+    assert "num_layers=2" in out
+    assert "unsup=0.2" in out

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,7 @@
+from causal_consistency_nn.utils import logging as clog
+
+
+def test_log(capsys) -> None:
+    clog.log("hello")
+    captured = capsys.readouterr().out
+    assert "hello" in captured


### PR DESCRIPTION
## Summary
- provide Dockerfile with CPU and CUDA variants
- orchestrate `train` and `serve` with docker-compose
- document container workflow in README and docs
- build container images in CI
- test additional CLI branches and logging for coverage

## Testing
- `black .`
- `ruff check --fix .`
- `pytest --cov=src --cov=tests --cov-report=term --cov-fail-under=90`

------
https://chatgpt.com/codex/tasks/task_e_68534058723483249149247be691cc84