### PR TITLE
Improve documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,10 @@
+# API Reference
+
+This section is automatically generated using the
+[`mkdocstrings`](https://mkdocstrings.github.io/) plugin for MkDocs.
+It pulls docstrings from the Python source code to provide up-to-date
+reference material.
+
+::: causal_consistency_nn.train
+
+::: causal_consistency_nn.eval

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,35 @@
+# Customising Configurations
+
+All settings are managed by the `Settings` class in `config.py`. The default
+values are reasonable for small experiments but most projects will want to tweak
+them. Configuration can come from three sources:
+
+1. A YAML file supplied via `--config`.
+2. Environment variables using the `SECTION__FIELD` notation.
+3. Command line flags which take highest priority.
+
+Below is a minimal configuration file illustrating the available sections:
+
+```yaml
+model:
+  hidden_dim: 64
+  num_layers: 2
+loss:
+  z_yx: 1.0
+  y_xz: 1.0
+  x_yz: 1.0
+  unsup: 0.0
+train:
+  batch_size: 32
+  epochs: 10
+  learning_rate: 1e-3
+data:
+  n_samples: 1000
+  noise_std: 0.1
+  missing_y_prob: 0.0
+```
+
+To override a single value without editing the file you can pass something like
+`--train-batch-size 64` or set `LOSS__UNSUP=0.5` in the environment. The
+resolved configuration is printed at the start of each run so that experiments
+are fully reproducible.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,13 @@
 # Documentation
 
-This project implements the causal-consistency neural network described in `Prompt.txt`. The codebase now exposes a YAML-based configuration system and a modular set of model components.
+This project implements the causal-consistency neural network described in
+`Prompt.txt`. The documentation is organised into several sections covering
+training, evaluation and configuration. The API reference is generated
+automatically via MkDocs.
+
+For a guided introduction see
+the [training guide](training.md), the [metrics documentation](metrics.md) and
+the [configuration reference](configuration.md).
 
 ## Configuration system
 Configuration files live in the `configs/` directory and are parsed with `pydantic` dataclasses. All hyperparameters, such as backbone size or loss weights, can be changed in the YAML file or overridden via CLI flags:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,24 @@
+# Evaluation Metrics
+
+The project provides helper utilities to evaluate trained models. The main entry
+point is `eval.py` which reports both log-likelihood and causal metrics.
+
+## Running the evaluator
+
+```bash
+python src/causal_consistency_nn/eval.py --config examples/scripts/train_config.yaml \
+    --model-path <run_dir>/model.pt
+```
+
+The script loads the saved `Settings` from the YAML file, restores the model and
+runs evaluation on a freshly generated synthetic dataset. The resulting metrics
+are printed in YAML format for easy consumption.
+
+## Available metrics
+
+- **Log Likelihood** – Average negative log probability of observed `Z` values.
+- **Average Treatment Effect (ATE)** – The difference in mean predicted `Z`
+  between treatment and control groups.
+
+Additional metrics can be implemented by extending `metrics.py` and importing
+those functions in `eval.py`.

--- a/docs/training.md
+++ b/docs/training.md
@@ -1,0 +1,34 @@
+# Training Usage
+
+This section covers how to launch a training run using the provided command line interface.
+
+## Basic invocation
+
+The simplest way to start training on the synthetic data generator is:
+
+```bash
+python src/causal_consistency_nn/train.py --config examples/scripts/train_config.yaml
+```
+
+The script reads the YAML file and constructs the `Settings` dataclass which groups
+all configuration sections. A run directory is created under the current working
+folder to store the checkpoint and the resolved configuration.
+
+## Adjusting hyperparameters
+
+Command line flags override values from the YAML file. For example, to increase
+the hidden dimension and enable a small amount of unsupervised loss you can run:
+
+```bash
+python src/causal_consistency_nn/train.py --config examples/scripts/train_config.yaml \
+    --model-hidden-dim 128 --loss-unsup 0.1
+```
+
+Environment variables may also override nested fields using the `SECTION__FIELD`
+convention, e.g. `TRAIN__EPOCHS=20`.
+
+## Checkpoints and logging
+
+After each epoch the model state is written to `<run_dir>/model.pt`. Logs are
+printed to stdout and can be captured with any standard tool such as
+`tee` or `wandb` integration if desired.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,14 @@
+site_name: Causal Consistency NN
+nav:
+  - Home: docs/index.md
+  - Training: docs/training.md
+  - Evaluation Metrics: docs/metrics.md
+  - Configuration: docs/configuration.md
+  - API Reference: docs/api.md
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          setup_commands:
+            - import sys; sys.path.append('src')


### PR DESCRIPTION
## Summary
- add mkdocs config for API docs
- document training usage
- document evaluation metrics
- show how to customise configurations
- include minimal API reference page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685340ff465c83249e83007450b7c631