### PR TITLE
Add FastAPI server wrapper

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,3 +62,10 @@ calculations.
 `serve.py` provides a minimal API for inference with a trained model. Functions
 `predict_z`, `counterfactual_z` and `impute_y` wrap the network's heads for
 easy integration in production services.
+A lightweight FastAPI application is available in `fastapi_app.py`. Use
+`create_app(model)` in your own code or run the module directly to expose the
+three inference endpoints:
+
+```bash
+python -m causal_consistency_nn.fastapi_app --model-path run/model.pt --config examples/scripts/train_config.yaml
+```

--- a/src/causal_consistency_nn/fastapi_app.py
+++ b/src/causal_consistency_nn/fastapi_app.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+import argparse
+
+import torch
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .eval import load_model
+from .serve import counterfactual_z, impute_y, predict_z
+from .config import Settings
+from .train import ConsistencyModel
+
+
+class PredictRequest(BaseModel):
+    x: list[list[float]]
+    y: list[int]
+
+
+class CounterfactualRequest(BaseModel):
+    x: list[list[float]]
+    y_prime: list[int]
+
+
+class ImputeRequest(BaseModel):
+    x: list[list[float]]
+    z: list[list[float]]
+
+
+def create_app(model: ConsistencyModel) -> FastAPI:
+    """Return a FastAPI app exposing the inference helpers."""
+
+    app = FastAPI()
+    app.state.model = model
+
+    @app.post("/predict_z")
+    def _predict(req: PredictRequest) -> dict[str, list[list[float]]]:
+        x = torch.tensor(req.x, dtype=torch.float32)
+        y = torch.tensor(req.y, dtype=torch.long)
+        out = predict_z(app.state.model, x, y)
+        return {"z": out.tolist()}
+
+    @app.post("/counterfactual_z")
+    def _counter(req: CounterfactualRequest) -> dict[str, list[list[float]]]:
+        x = torch.tensor(req.x, dtype=torch.float32)
+        y_prime = torch.tensor(req.y_prime, dtype=torch.long)
+        out = counterfactual_z(app.state.model, x, y_prime)
+        return {"z": out.tolist()}
+
+    @app.post("/impute_y")
+    def _impute(req: ImputeRequest) -> dict[str, list[list[float]]]:
+        x = torch.tensor(req.x, dtype=torch.float32)
+        z = torch.tensor(req.z, dtype=torch.float32)
+        out = impute_y(app.state.model, x, z)
+        return {"y_prob": out.tolist()}
+
+    return app
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Serve a trained model via FastAPI")
+    parser.add_argument("--model-path", type=Path, required=True)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8000)
+    args = parser.parse_args(argv)
+
+    settings = Settings.from_yaml(args.config)
+    model = load_model(args.model_path, settings)
+    app = create_app(model)
+
+    import uvicorn
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+import torch
+
+from causal_consistency_nn import train
+from causal_consistency_nn.config import Settings
+from causal_consistency_nn.data import get_synth_dataloaders
+from causal_consistency_nn.fastapi_app import create_app
+
+
+def test_fastapi_endpoints() -> None:
+    settings = Settings()
+    settings.train.epochs = 1
+    sup, unsup = get_synth_dataloaders(
+        settings.data, batch_size=settings.train.batch_size, seed=0
+    )
+    x_ex, y_ex, z_ex = next(iter(sup))
+    model = train.ConsistencyModel(
+        x_ex.shape[1], int(y_ex.max().item()) + 1, z_ex.shape[1], settings.model
+    )
+    train.train_em(model, sup, unsup, train.EMConfig(epochs=1))
+
+    app = create_app(model)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/predict_z",
+        json={"x": x_ex.tolist(), "y": y_ex.tolist()},
+    )
+    assert resp.status_code == 200
+    assert torch.tensor(resp.json()["z"]).shape == z_ex.shape
+
+    resp = client.post(
+        "/counterfactual_z",
+        json={"x": x_ex.tolist(), "y_prime": (1 - y_ex).tolist()},
+    )
+    assert resp.status_code == 200
+    assert torch.tensor(resp.json()["z"]).shape == z_ex.shape
+
+    resp = client.post(
+        "/impute_y",
+        json={"x": x_ex.tolist(), "z": z_ex.tolist()},
+    )
+    assert resp.status_code == 200
+    prob = torch.tensor(resp.json()["y_prob"])
+    assert prob.shape[0] == y_ex.shape[0]
+    assert torch.allclose(prob.sum(-1), torch.ones_like(prob[:, 0]), atol=1e-5)


### PR DESCRIPTION
## Summary
- implement a simple FastAPI service in `fastapi_app.py`
- document how to launch the service
- add tests exercising the new endpoints

## Testing
- `ruff check --fix src tests docs`
- `black src tests docs`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685340cc91ec83249b7816c0bf355576