### PR TITLE
Add CLI entrypoint

### DIFF
--- a/src/causal_consistency_nn/__main__.py
+++ b/src/causal_consistency_nn/__main__.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def _run_train(args: list[str]) -> None:
+    from . import train
+
+    train.main(args)
+
+
+def _run_eval(args: list[str]) -> None:
+    from . import eval as eval_mod
+
+    eval_mod.main(args)
+
+
+def _run_serve(args: list[str]) -> None:
+    from . import fastapi_app
+
+    fastapi_app.main(args)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="causal_consistency_nn",
+        description="Causal consistency neural network utilities",
+    )
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("train", help="Train a model")
+    sub.add_parser("eval", help="Evaluate a trained model")
+    sub.add_parser("serve", help="Serve a trained model via FastAPI")
+
+    if argv is None:
+        argv = sys.argv[1:]
+    if not argv:
+        parser.print_help()
+        return
+
+    args, extra = parser.parse_known_args(argv)
+
+    if args.command == "train":
+        _run_train(extra)
+    elif args.command == "eval":
+        _run_eval(extra)
+    elif args.command == "serve":
+        _run_serve(extra)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from causal_consistency_nn import __main__
+
+
+def test_package_help(capsys) -> None:
+    __main__.main([])
+    out = capsys.readouterr().out
+    assert "train" in out
+    assert "eval" in out
+    assert "serve" in out


### PR DESCRIPTION
## Summary
- expose new package CLI in `causal_consistency_nn.__main__`
- run help by default and dispatch to train/eval/serve
- test the package-level CLI

## Testing
- `ruff check src tests`
- `black --check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853480f57f88324a0b65d3b29f4c20d