### PR TITLE
Add FastAPI server deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ This repository provides an implementation of the causal-consistency neural netw
 ## Quick start
 
 ```bash
-poetry install  # installs torch, pyro, pydantic and pydantic-settings
+poetry install  # installs torch, pyro, pydantic, pydantic-settings, fastapi and uvicorn
 poetry run python src/train.py
 ```
 
 If you prefer using `pip` directly, install the dependencies first:
 
 ```bash
-pip install torch pyro-ppl pydantic pydantic-settings
+pip install torch pyro-ppl pydantic pydantic-settings fastapi uvicorn
 pip install -e .
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ torch = "2.7.1"
 pyro-ppl = "1.9.1"
 pydantic = "^2.7"
 pydantic-settings = "^2.2"
+fastapi = "^0.111"
+uvicorn = "^0.30"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4"


### PR DESCRIPTION
## Summary
- include FastAPI runtime packages in Poetry dependencies
- mention FastAPI and Uvicorn in README install steps

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68534812a37c8324a12ed376d5d0e69a