### PR TITLE
Fix docs index formatting

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,14 +70,14 @@ calculations.
 `predict_z`, `counterfactual_z` and `impute_y` wrap the network's heads for
 easy integration in production services.
 
-A lightweight FastAPI application is available in `fastapi_app.py`. Use
+A lightweight FastAPI application is available in
+[`fastapi_app.py`](../src/causal_consistency_nn/fastapi_app.py). Use
 `create_app(model)` in your own code or run the module directly to expose the
 three inference endpoints:
 
 ```bash
 python -m causal_consistency_nn.fastapi_app --model-path run/model.pt --config examples/scripts/train_config.yaml
 ```
-=======
 
 ## Docker workflow
 Both CPU and CUDA images can be built from the provided `Dockerfile`. Use

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,14 +1,14 @@
 site_name: Causal Consistency NN
 nav:
-  - Home: docs/index.md
-  - Training: docs/training.md
-  - Evaluation Metrics: docs/metrics.md
-  - Configuration: docs/configuration.md
-  - API Reference: docs/api.md
+  - Home: index.md
+  - Training: training.md
+  - Evaluation Metrics: metrics.md
+  - Configuration: configuration.md
+  - API Reference: api.md
 plugins:
   - search
   - mkdocstrings:
       handlers:
         python:
-          setup_commands:
-            - import sys; sys.path.append('src')
+          paths:
+            - src


### PR DESCRIPTION
## Summary
- fix mkdocstrings config for new version
- remove stray markers from docs
- cross-link FastAPI section to entrypoint

## Testing
- `mkdocs build`
- `mkdocs serve --dev-addr localhost:8001`
- `black --check .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68534815feb48324b6a5eaa9e63b74ed