### PR TITLE
Add soft EM expectation and entropy

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -39,3 +39,17 @@ convention, e.g. `TRAIN__EPOCHS=20`.
 After each epoch the model state is written to `<run_dir>/model.pt`. Logs are
 printed to stdout and can be captured with any standard tool such as
 `tee` or `wandb` integration if desired.
+
+## Soft-EM option
+
+When labels for `Y` are missing the training loop can perform soft updates.
+Predicted class probabilities are used instead of hard argmaxes and an entropy
+regulariser scaled by `tau` encourages exploration. The unsupervised objective
+is weighted by `beta` and includes the entropy term:
+
+```math
+L_{unsup} = \beta \mathbb{E}_{p(y|x,z)}[L_z + L_x] - \tau H[p(y|x,z)].
+```
+
+Increasing `tau` yields smoother pseudo-labels while decreasing it approaches
+standard EM.

--- a/tests/test_semi_loop.py
+++ b/tests/test_semi_loop.py
@@ -2,6 +2,7 @@ import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
+from causal_consistency_nn.model import semi_loop
 from causal_consistency_nn.model.semi_loop import EMConfig, train_em
 
 
@@ -59,3 +60,40 @@ def test_train_em_reduces_loss() -> None:
     train_em(model, sup_loader, unsup_loader, config)
     loss_after = eval_loss()
     assert loss_after < loss_before
+
+
+def test_soft_em_loss_decreases(capsys) -> None:
+    sup_loader, unsup_loader = create_data()
+    model = DummyModel()
+    config = EMConfig(epochs=3, lr=0.01, beta=1.0, tau=0.5)
+
+    train_em(model, sup_loader, unsup_loader, config)
+    out_lines = [
+        line
+        for line in capsys.readouterr().out.splitlines()
+        if "unsupervised_loss=" in line
+    ]
+    losses = [float(line.split("unsupervised_loss=")[1]) for line in out_lines]
+    assert losses[-1] < losses[0]
+
+
+class EntropyModel(nn.Module):
+    def head_y_given_xz(self, x: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
+        return torch.zeros(len(x), 2)
+
+    def head_z_given_xy(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return torch.zeros_like(x)
+
+    def head_x_given_yz(self, y: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
+        return torch.zeros(len(y), 1)
+
+
+def test_entropy_term() -> None:
+    model = EntropyModel()
+    x = torch.randn(4, 1)
+    z = torch.randn(4, 1)
+    cfg = EMConfig(lambda1=0.0, lambda3=0.0, beta=1.0, tau=2.0)
+    loss = semi_loop._unsupervised_step(model, (x, z), cfg, nn.MSELoss())
+    entropy = -(torch.tensor([0.5, 0.5]) * torch.log(torch.tensor([0.5, 0.5]))).sum()
+    expected = -cfg.tau * entropy
+    assert torch.isclose(loss, expected, atol=1e-4)


### PR DESCRIPTION
## Summary
- implement soft EM updates using expectation over probabilities and an entropy regulariser
- log the unsupervised loss each epoch
- document `tau` and soft EM behaviour
- test entropy term and decreasing loss

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685351b5e308832498149137388de69b