### PR TITLE
Fix training config section name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ poetry run python src/train.py        # plain PyTorch EM loop
 poetry run python src/train.py --use-pyro  # train with Pyro SVI
 ```
 
+Training settings are defined under the `train:` section of
+`examples/scripts/train_config.yaml`.
+
 If you prefer using `pip` directly, install the dependencies first:
 
 ```bash

--- a/examples/scripts/train_config.yaml
+++ b/examples/scripts/train_config.yaml
@@ -1,5 +1,5 @@
 # Example configuration for training on synthetic data
 model:
   hidden_dim: 32
-training:
+train:
   epochs: 10


### PR DESCRIPTION
## Summary
- fix the example YAML to use `train:`
- clarify in README that training settings live under the `train:` section

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853594dfe5c83248353a8769ea8fa14