### PR TITLE
Add MAR/MNAR synthetic data and integration test

### DIFF
--- a/src/causal_consistency_nn/data/__init__.py
+++ b/src/causal_consistency_nn/data/__init__.py
@@ -1,6 +1,21 @@
 """Data loading utilities."""
 
 from .dummy import load_dummy
-from .synthetic import generate_synthetic, get_synth_dataloaders
+from .synthetic import (
+    generate_synthetic,
+    generate_synthetic_mar,
+    generate_synthetic_mnar,
+    get_synth_dataloaders,
+    get_synth_dataloaders_mar,
+    get_synth_dataloaders_mnar,
+)
 
-__all__ = ["load_dummy", "generate_synthetic", "get_synth_dataloaders"]
+__all__ = [
+    "load_dummy",
+    "generate_synthetic",
+    "generate_synthetic_mar",
+    "generate_synthetic_mnar",
+    "get_synth_dataloaders",
+    "get_synth_dataloaders_mar",
+    "get_synth_dataloaders_mnar",
+]

--- a/src/causal_consistency_nn/data/synthetic.py
+++ b/src/causal_consistency_nn/data/synthetic.py
@@ -8,6 +8,18 @@ from torch.utils.data import DataLoader, TensorDataset
 from ..config import SyntheticDataConfig
 
 
+def _sample_xyz(
+    cfg: SyntheticDataConfig, g: torch.Generator
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Sample ``X``, ``Y`` and ``Z`` following the base SCM."""
+    x = torch.randn(cfg.n_samples, 1, generator=g)
+    probs = torch.sigmoid(x.squeeze())
+    y = torch.bernoulli(probs, generator=g).long()
+    noise = torch.randn(cfg.n_samples, 1, generator=g) * cfg.noise_std
+    z = x + y.float().unsqueeze(-1) + noise
+    return x, y, z
+
+
 def generate_synthetic(
     cfg: SyntheticDataConfig, seed: int | None = None
 ) -> TensorDataset:
@@ -35,6 +47,38 @@ def generate_synthetic(
     return TensorDataset(x, y, z, mask)
 
 
+def generate_synthetic_mar(
+    cfg: SyntheticDataConfig, seed: int | None = None
+) -> TensorDataset:
+    """Generate data with MAR missingness depending on ``X``."""
+    g = torch.Generator()
+    if seed is not None:
+        g.manual_seed(seed)
+
+    x, y, z = _sample_xyz(cfg, g)
+    miss_prob = cfg.missing_y_prob * torch.sigmoid(x.squeeze())
+    mask = torch.rand(cfg.n_samples, generator=g) > miss_prob
+    mask = mask.to(torch.bool)
+
+    return TensorDataset(x, y, z, mask)
+
+
+def generate_synthetic_mnar(
+    cfg: SyntheticDataConfig, seed: int | None = None
+) -> TensorDataset:
+    """Generate data with MNAR missingness depending on ``Y``."""
+    g = torch.Generator()
+    if seed is not None:
+        g.manual_seed(seed)
+
+    x, y, z = _sample_xyz(cfg, g)
+    miss_prob = cfg.missing_y_prob * (0.5 + 0.5 * y.float())
+    mask = torch.rand(cfg.n_samples, generator=g) > miss_prob
+    mask = mask.to(torch.bool)
+
+    return TensorDataset(x, y, z, mask)
+
+
 def get_synth_dataloaders(
     cfg: SyntheticDataConfig, batch_size: int, seed: int | None = None
 ) -> Tuple[DataLoader, DataLoader]:
@@ -53,4 +97,47 @@ def get_synth_dataloaders(
     return sup_loader, unsup_loader
 
 
-__all__ = ["generate_synthetic", "get_synth_dataloaders"]
+def get_synth_dataloaders_mar(
+    cfg: SyntheticDataConfig, batch_size: int, seed: int | None = None
+) -> Tuple[DataLoader, DataLoader]:
+    """Dataloaders from ``generate_synthetic_mar``."""
+    dataset = generate_synthetic_mar(cfg, seed)
+    x, y, z, mask = dataset.tensors
+
+    sup_ds = TensorDataset(x[mask], y[mask], z[mask])
+    unsup_ds = TensorDataset(x[~mask], z[~mask])
+
+    sup_loader = DataLoader(sup_ds, batch_size=batch_size, shuffle=True)
+    if len(unsup_ds) > 0:
+        unsup_loader = DataLoader(unsup_ds, batch_size=batch_size, shuffle=True)
+    else:
+        unsup_loader = DataLoader(unsup_ds, batch_size=batch_size, shuffle=False)
+    return sup_loader, unsup_loader
+
+
+def get_synth_dataloaders_mnar(
+    cfg: SyntheticDataConfig, batch_size: int, seed: int | None = None
+) -> Tuple[DataLoader, DataLoader]:
+    """Dataloaders from ``generate_synthetic_mnar``."""
+    dataset = generate_synthetic_mnar(cfg, seed)
+    x, y, z, mask = dataset.tensors
+
+    sup_ds = TensorDataset(x[mask], y[mask], z[mask])
+    unsup_ds = TensorDataset(x[~mask], z[~mask])
+
+    sup_loader = DataLoader(sup_ds, batch_size=batch_size, shuffle=True)
+    if len(unsup_ds) > 0:
+        unsup_loader = DataLoader(unsup_ds, batch_size=batch_size, shuffle=True)
+    else:
+        unsup_loader = DataLoader(unsup_ds, batch_size=batch_size, shuffle=False)
+    return sup_loader, unsup_loader
+
+
+__all__ = [
+    "generate_synthetic",
+    "generate_synthetic_mar",
+    "generate_synthetic_mnar",
+    "get_synth_dataloaders",
+    "get_synth_dataloaders_mar",
+    "get_synth_dataloaders_mnar",
+]

--- a/tests/test_integration_missing_y.py
+++ b/tests/test_integration_missing_y.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+import pytest
+
+from causal_consistency_nn.config import ModelConfig, SyntheticDataConfig
+from causal_consistency_nn.data.synthetic import (
+    get_synth_dataloaders_mar,
+    get_synth_dataloaders_mnar,
+    generate_synthetic,
+)
+from causal_consistency_nn.train import ConsistencyModel
+from causal_consistency_nn.model.semi_loop import EMConfig, train_em
+from causal_consistency_nn.metrics import dataset_log_likelihood
+
+
+@pytest.mark.parametrize(
+    "loader_fn", [get_synth_dataloaders_mar, get_synth_dataloaders_mnar]
+)
+def test_semi_supervised_beats_supervised(loader_fn) -> None:
+    cfg = SyntheticDataConfig(n_samples=400, noise_std=0.1, missing_y_prob=0.5)
+    sup_loader, unsup_loader = loader_fn(cfg, batch_size=32, seed=0)
+
+    x_ex, y_ex, z_ex = next(iter(sup_loader))
+    model_sup = ConsistencyModel(
+        x_ex.shape[1], int(y_ex.max()) + 1, z_ex.shape[1], ModelConfig()
+    )
+    model_semi = ConsistencyModel(
+        x_ex.shape[1], int(y_ex.max()) + 1, z_ex.shape[1], ModelConfig()
+    )
+
+    train_em(model_sup, sup_loader, unsup_loader, EMConfig(beta=0.0, epochs=4, lr=0.01))
+    train_em(
+        model_semi, sup_loader, unsup_loader, EMConfig(beta=1.0, epochs=4, lr=0.01)
+    )
+
+    val_cfg = SyntheticDataConfig(n_samples=200, noise_std=0.1, missing_y_prob=0.0)
+    val_ds = generate_synthetic(val_cfg, seed=1)
+    x_val, y_val, z_val, _ = val_ds.tensors
+    val_loader = DataLoader(TensorDataset(x_val, y_val, z_val), batch_size=64)
+
+    ll_sup = dataset_log_likelihood(model_sup, val_loader)
+    ll_semi = dataset_log_likelihood(model_semi, val_loader)
+    assert ll_semi > ll_sup
+
+    with torch.no_grad():
+        z1_sup = model_sup.head_z_given_xy(
+            x_val, torch.ones(len(x_val), dtype=torch.long)
+        )
+        z0_sup = model_sup.head_z_given_xy(
+            x_val, torch.zeros(len(x_val), dtype=torch.long)
+        )
+        z1_semi = model_semi.head_z_given_xy(
+            x_val, torch.ones(len(x_val), dtype=torch.long)
+        )
+        z0_semi = model_semi.head_z_given_xy(
+            x_val, torch.zeros(len(x_val), dtype=torch.long)
+        )
+
+    ate_true = 1.0
+    err_sup = abs((z1_sup - z0_sup).mean().item() - ate_true)
+    err_semi = abs((z1_semi - z0_semi).mean().item() - ate_true)
+    assert err_semi < err_sup


### PR DESCRIPTION
## Summary
- extend synthetic dataset module with MAR and MNAR generators
- re-export the new helpers
- add integration test to compare supervised vs semi-supervised training on MAR and MNAR datasets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536f0e2a00832485c0615760514bc4