### PR TITLE
Fix config key usage

### DIFF
--- a/examples/scripts/train_config.yaml
+++ b/examples/scripts/train_config.yaml
@@ -1,5 +1,5 @@
 # Example configuration for training on synthetic data
 model:
   hidden_dim: 32
-training:
+train:
   epochs: 10

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,3 +31,15 @@ def test_settings_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setenv("MODEL__NUM_LAYERS", "4")
     s = Settings.from_yaml(cfg)
     assert s.model.num_layers == 4
+
+
+def test_example_config_loads() -> None:
+    cfg = (
+        Path(__file__).resolve().parents[1]
+        / "examples"
+        / "scripts"
+        / "train_config.yaml"
+    )
+    s = Settings.from_yaml(cfg)
+    assert s.train.epochs == 10
+    assert s.model.hidden_dim == 32


### PR DESCRIPTION
## Summary
- update sample config to use `train:` section
- test loading of example config

## Testing
- `ruff check tests/test_config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536f12d4508324b26bffffd91720c3