### PR TITLE
Add lockfile copy in training outputs

### DIFF
--- a/src/causal_consistency_nn/train.py
+++ b/src/causal_consistency_nn/train.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import shutil
 from pathlib import Path
 
 import yaml
@@ -98,6 +99,12 @@ def run_training(settings: Settings, out_dir: Path) -> None:
     torch.save(model.state_dict(), out_dir / "model.pt")
     with (out_dir / "config.yaml").open("w") as handle:
         yaml.safe_dump(settings.model_dump(), handle)
+
+    # Copy environment lockfile for reproducibility
+    repo_root = Path(__file__).resolve().parents[2]
+    lockfile = repo_root / "conda-lock.yml"
+    if lockfile.exists():
+        shutil.copy(lockfile, out_dir / "conda-lock.yml")
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/tests/test_train_end_to_end.py
+++ b/tests/test_train_end_to_end.py
@@ -45,3 +45,4 @@ def test_train_end_to_end(tmp_path: Path) -> None:
     train.run_training(settings, out_dir)
     assert (out_dir / "model.pt").exists()
     assert (out_dir / "config.yaml").exists()
+    assert (out_dir / "conda-lock.yml").exists()


### PR DESCRIPTION
## Summary
- copy `conda-lock.yml` to the training output directory
- ensure tests expect the lockfile

## Testing
- `ruff check src/causal_consistency_nn/train.py tests/test_train_end_to_end.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536f1cae588324a578af003994fae9