### PR TITLE
Add TorchServe handler and docs

### DIFF
--- a/docs/serving.md
+++ b/docs/serving.md
@@ -1,0 +1,34 @@
+# Serving with Torch-Serve
+
+This project can be deployed using [Torch-Serve](https://pytorch.org/serve/). After training you will have a `model.pt` checkpoint and the `config.yaml` used during training. These files are required by the custom handler.
+
+```bash
+# Package the model
+torch-model-archiver \
+    --model-name causal \
+    --version 1.0 \
+    --serialized-file <run_dir>/model.pt \
+    --handler src/causal_consistency_nn/torchserve_handler.py \
+    --extra-files <run_dir>/config.yaml
+
+mkdir model_store
+mv causal.mar model_store/
+
+# Launch the server
+torchserve --start --ncs --model-store model_store --models causal=causal.mar
+```
+
+Requests are sent to the `predictions` endpoint. The payload must include an `action` field selecting one of the inference helpers:
+
+- `predict_z` – return `E[Z|X,Y]`
+- `counterfactual_z` – predict `Z` under an alternate treatment
+- `impute_y` – posterior probabilities of `Y`
+
+Example request using `curl`:
+
+```bash
+curl -X POST http://localhost:8080/predictions/causal \
+    -d '{"action":"impute_y","x": [[0.2]], "z": [[1.0]]}'
+```
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Causal Consistency NN
 nav:
   - Home: index.md
   - Training: training.md
+  - Serving: serving.md
   - Evaluation Metrics: metrics.md
   - Model Card: model_card.md
   - Configuration: configuration.md

--- a/src/causal_consistency_nn/torchserve_handler.py
+++ b/src/causal_consistency_nn/torchserve_handler.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from .config import Settings
+from .eval import load_model
+from .serve import counterfactual_z, impute_y, predict_z
+
+
+_model = None
+
+
+def _get_model(context: Any) -> torch.nn.Module:
+    global _model
+    if _model is not None:
+        return _model
+    model_dir = Path(getattr(context, "system_properties", {}).get("model_dir", "."))
+    model_path = model_dir / "model.pt"
+    cfg_path = model_dir / "config.yaml"
+    settings = Settings.from_yaml(cfg_path)
+    _model = load_model(model_path, settings)
+    return _model
+
+
+def _parse(data: Any) -> dict[str, Any]:
+    if isinstance(data, (bytes, bytearray)):
+        data = data.decode("utf-8")
+    if isinstance(data, str):
+        return json.loads(data)
+    return data
+
+
+def handle(data: list[dict[str, Any]], context: Any) -> Any:
+    """Entry point used by Torch-Serve."""
+    if not data:
+        return None
+    payload = _parse(data[0].get("body", data[0].get("data", data[0])))
+    model = _get_model(context)
+
+    action = payload.get("action")
+    if action == "predict_z":
+        x = torch.tensor(payload["x"], dtype=torch.float32)
+        y = torch.tensor(payload["y"], dtype=torch.long)
+        out = predict_z(model, x, y)
+        return out.tolist()
+    if action == "counterfactual_z":
+        x = torch.tensor(payload["x"], dtype=torch.float32)
+        y_prime = torch.tensor(payload["y_prime"], dtype=torch.long)
+        out = counterfactual_z(model, x, y_prime)
+        return out.tolist()
+    if action == "impute_y":
+        x = torch.tensor(payload["x"], dtype=torch.float32)
+        z = torch.tensor(payload["z"], dtype=torch.float32)
+        out = impute_y(model, x, z)
+        return out.tolist()
+
+    raise ValueError(f"Unknown action: {action}")

--- a/tests/test_torchserve_handler.py
+++ b/tests/test_torchserve_handler.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import torch
+import yaml
+
+from causal_consistency_nn import train
+from causal_consistency_nn.config import Settings
+from causal_consistency_nn.data import get_synth_dataloaders
+from causal_consistency_nn.torchserve_handler import handle
+
+
+class DummyCtx:
+    def __init__(self, model_dir: Path) -> None:
+        self.system_properties = {"model_dir": str(model_dir)}
+
+
+def test_handle_shapes(tmp_path: Path) -> None:
+    settings = Settings()
+    settings.train.epochs = 1
+    sup, unsup = get_synth_dataloaders(
+        settings.data, batch_size=settings.train.batch_size, seed=0
+    )
+    x_ex, y_ex, z_ex = next(iter(sup))
+    model = train.ConsistencyModel(
+        x_ex.shape[1], int(y_ex.max().item()) + 1, z_ex.shape[1], settings.model
+    )
+    train.train_em(model, sup, unsup, train.EMConfig(epochs=1))
+
+    torch.save(model.state_dict(), tmp_path / "model.pt")
+    with (tmp_path / "config.yaml").open("w") as fh:
+        yaml.safe_dump(settings.model_dump(exclude={"config_path"}), fh)
+
+    ctx = DummyCtx(tmp_path)
+
+    req = [
+        {
+            "body": json.dumps(
+                {"action": "predict_z", "x": x_ex.tolist(), "y": y_ex.tolist()}
+            )
+        }
+    ]
+    out = handle(req, ctx)
+    assert torch.tensor(out).shape == z_ex.shape
+
+    req = [
+        {
+            "body": json.dumps(
+                {"action": "impute_y", "x": x_ex.tolist(), "z": z_ex.tolist()}
+            )
+        }
+    ]
+    out = handle(req, ctx)
+    assert torch.tensor(out).shape[0] == y_ex.shape[0]
+
+    req = [
+        {
+            "body": json.dumps(
+                {
+                    "action": "counterfactual_z",
+                    "x": x_ex.tolist(),
+                    "y_prime": (1 - y_ex).tolist(),
+                }
+            )
+        }
+    ]
+    out = handle(req, ctx)
+    assert torch.tensor(out).shape == z_ex.shape


### PR DESCRIPTION
## Summary
- implement `torchserve_handler.handle()` to load model and dispatch inference
- document Torch‑Serve workflow
- hook the doc page into `mkdocs.yml`
- test the handler with a dummy payload

## Testing
- `ruff check src tests`
- `black src tests`
- `pytest --cov=src --cov=tests --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_68536f2b55d88324aaaa06d7a922fb3b