### PR TITLE
Fix CI dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install .
           pip install black ruff pytest pytest-cov
       - name: Run formatters
         run: |


### PR DESCRIPTION
## Summary
- install the project before running checks so torch et al. are available

## Testing
- `pytest -q` *(fails: test_semi_supervised_beats_supervised)*

------
https://chatgpt.com/codex/tasks/task_e_685377f994208324aaf287dc0d745911