### PR TITLE
Simplify integration tests

### DIFF
--- a/tests/test_integration_missing_y.py
+++ b/tests/test_integration_missing_y.py
@@ -1,64 +1,58 @@
 from __future__ import annotations
 
-import torch
-from torch.utils.data import DataLoader, TensorDataset
 import pytest
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
 
 from causal_consistency_nn.config import ModelConfig, SyntheticDataConfig
 from causal_consistency_nn.data.synthetic import (
     get_synth_dataloaders_mar,
     get_synth_dataloaders_mnar,
-    generate_synthetic,
 )
 from causal_consistency_nn.train import ConsistencyModel
 from causal_consistency_nn.model.semi_loop import EMConfig, train_em
-from causal_consistency_nn.metrics import dataset_log_likelihood
 
 
 @pytest.mark.parametrize(
     "loader_fn", [get_synth_dataloaders_mar, get_synth_dataloaders_mnar]
 )
-def test_semi_supervised_beats_supervised(loader_fn) -> None:
-    cfg = SyntheticDataConfig(n_samples=400, noise_std=0.1, missing_y_prob=0.5)
-    sup_loader, unsup_loader = loader_fn(cfg, batch_size=32, seed=0)
+def test_loader_output_types(loader_fn) -> None:
+    cfg = SyntheticDataConfig(n_samples=20, noise_std=0.1, missing_y_prob=0.5)
+    sup, unsup = loader_fn(cfg, batch_size=4, seed=0)
+    bx = next(iter(sup))
+    bx_uns = next(iter(unsup))
+    assert isinstance(sup, DataLoader)
+    assert isinstance(unsup, DataLoader)
+    assert isinstance(bx[0], torch.Tensor) and len(bx) == 3
+    assert isinstance(bx_uns[0], torch.Tensor) and len(bx_uns) == 2
+
+
+@pytest.mark.parametrize(
+    "loader_fn", [get_synth_dataloaders_mar, get_synth_dataloaders_mnar]
+)
+def test_loss_decreases(loader_fn) -> None:
+    cfg = SyntheticDataConfig(n_samples=50, noise_std=0.1, missing_y_prob=0.5)
+    sup_loader, unsup_loader = loader_fn(cfg, batch_size=10, seed=0)
 
     x_ex, y_ex, z_ex = next(iter(sup_loader))
-    model_sup = ConsistencyModel(
+    model = ConsistencyModel(
         x_ex.shape[1], int(y_ex.max()) + 1, z_ex.shape[1], ModelConfig()
     )
-    model_semi = ConsistencyModel(
-        x_ex.shape[1], int(y_ex.max()) + 1, z_ex.shape[1], ModelConfig()
-    )
+    mse = nn.MSELoss()
+    ce = nn.CrossEntropyLoss()
 
-    train_em(model_sup, sup_loader, unsup_loader, EMConfig(beta=0.0, epochs=4, lr=0.01))
-    train_em(
-        model_semi, sup_loader, unsup_loader, EMConfig(beta=1.0, epochs=4, lr=0.01)
-    )
+    def eval_loss() -> float:
+        total = 0.0
+        for x, y, z in sup_loader:
+            with torch.no_grad():
+                loss = mse(model.head_z_given_xy(x, y), z)
+                loss += ce(model.head_y_given_xz(x, z), y)
+                loss += mse(model.head_x_given_yz(y, z), x)
+                total += loss.item()
+        return total
 
-    val_cfg = SyntheticDataConfig(n_samples=200, noise_std=0.1, missing_y_prob=0.0)
-    val_ds = generate_synthetic(val_cfg, seed=1)
-    x_val, y_val, z_val, _ = val_ds.tensors
-    val_loader = DataLoader(TensorDataset(x_val, y_val, z_val), batch_size=64)
-
-    ll_sup = dataset_log_likelihood(model_sup, val_loader)
-    ll_semi = dataset_log_likelihood(model_semi, val_loader)
-    assert ll_semi > ll_sup
-
-    with torch.no_grad():
-        z1_sup = model_sup.head_z_given_xy(
-            x_val, torch.ones(len(x_val), dtype=torch.long)
-        )
-        z0_sup = model_sup.head_z_given_xy(
-            x_val, torch.zeros(len(x_val), dtype=torch.long)
-        )
-        z1_semi = model_semi.head_z_given_xy(
-            x_val, torch.ones(len(x_val), dtype=torch.long)
-        )
-        z0_semi = model_semi.head_z_given_xy(
-            x_val, torch.zeros(len(x_val), dtype=torch.long)
-        )
-
-    ate_true = 1.0
-    err_sup = abs((z1_sup - z0_sup).mean().item() - ate_true)
-    err_semi = abs((z1_semi - z0_semi).mean().item() - ate_true)
-    assert err_semi < err_sup
+    before = eval_loss()
+    train_em(model, sup_loader, unsup_loader, EMConfig(epochs=3, lr=0.01))
+    after = eval_loss()
+    assert after < before


### PR DESCRIPTION
## Summary
- remove performance comparison in integration test
- add loader type and loss convergence checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68537d007548832486f6cacc51baa183