### PR TITLE
Add black and ruff configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.2
+    hooks:
+      - id: ruff
+        args: [--fix]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ pip install -e . pytest pytest-cov
 pytest --cov=src --cov=tests --cov-report=term --cov-fail-under=90
 ```
 
+## Pre-commit hooks
+
+Format and lint code automatically using [pre-commit](https://pre-commit.com/).
+Install the hooks once and they will run `black` and `ruff` on staged files:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+You can run all hooks manually with:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Containerised workflow
 
 The project ships with a `Dockerfile` and `docker-compose.yml` to simplify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,16 @@ pytest = "^7.4"
 black = "^23.7"
 ruff = "^0.4"
 
+[tool.black]
+line-length = 88
+target-version = ["py310"]
+extend-exclude = "/(docs|examples|tests/data)/"
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+extend-exclude = ["docs", "examples", "tests/data"]
+
 [build-system]
 requires = ["poetry-core>=1.6.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- configure Black and Ruff in pyproject.toml
- add a pre-commit hook running Black and Ruff
- document pre-commit usage in README

## Testing
- `black --check src tests examples`
- `ruff check src tests examples`
- `pytest --cov=src --cov=tests --cov-report=term --cov-fail-under=90 -q`

------
https://chatgpt.com/codex/tasks/task_e_6853883d85b08324931bfe847980aff0