### PR TITLE
Fix config key for multi-class example

### DIFF
--- a/examples/scripts/multi_class_config.yaml
+++ b/examples/scripts/multi_class_config.yaml
@@ -1,7 +1,7 @@
 # Example configuration for multi-class synthetic data
 model:
   hidden_dim: 32
-training:
+train:
   epochs: 10
 data:
   num_classes: 3


### PR DESCRIPTION
## Summary
- rename `training:` to `train:` in the multi-class config file

## Testing
- `black --check .`
- `ruff check .`
- `pytest --cov=src --cov=tests --cov-report=term --cov-fail-under=90`

------
https://chatgpt.com/codex/tasks/task_e_6853885716808324b579b82b6615747d