### PR TITLE
Add version constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,14 @@ docker compose run --service-ports serve
 
 The compose file mounts the repository in `/app` so outputs are written back to
 your local filesystem.
+
+## Package version
+
+The installed version of the library is exposed as `causal_consistency_nn.__version__`.
+It is read from `pyproject.toml` so it matches the package metadata:
+
+```python
+import causal_consistency_nn
+print(causal_consistency_nn.__version__)
+```
+

--- a/src/causal_consistency_nn/__init__.py
+++ b/src/causal_consistency_nn/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+import tomllib
+
+
+try:
+    __version__ = version("causal_consistency_nn")
+except PackageNotFoundError:  # pragma: no cover - fallback for editable install
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    __version__ = data["tool"]["poetry"]["version"]
+
+__all__ = ["__version__"]


### PR DESCRIPTION
## Summary
- expose `__version__` in `causal_consistency_nn` package
- document how to read the package version in README

## Testing
- `ruff check src/causal_consistency_nn/__init__.py`
- `black src/causal_consistency_nn/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685388591d148324bc177990e225d794