### PR TITLE
Add instrumental variable generator and head

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,10 +14,12 @@ Below is a minimal configuration file illustrating the available sections:
 model:
   hidden_dim: 64
   num_layers: 2
+  w_dim: 1
 loss:
   z_yx: 1.0
   y_xz: 1.0
   x_yz: 1.0
+  w_x: 1.0
   unsup: 0.0
 train:
   batch_size: 32
@@ -27,6 +29,9 @@ data:
   n_samples: 1000
   noise_std: 0.1
   missing_y_prob: 0.0
+  instrumental: false
+  w_dim: 1
+  w_y_strength: 1.0
 ```
 
 To override a single value without editing the file you can pass something like

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,13 +22,16 @@ The network is composed of a shared `Backbone` and three heads:
 - `ZgivenXY` predicts post-treatment variables `Z` from `X` and `Y`.
 - `YgivenXZ` estimates missing treatments from `X` and `Z`.
 - `XgivenYZ` reconstructs `X` given `Y` and `Z`.
+- `WgivenX` models instruments `W` conditional on `X`.
 
 These modules can be swapped or extended through the configuration system.
 
 ## Data generation
 Synthetic datasets following the $X \to Y \to Z$ structure can be generated with
-`examples/scripts/generate_synth.py`. The script outputs a small CSV file that is
-used throughout the examples and tests.
+`examples/scripts/generate_synth.py`. An alternative generator with an
+instrumental variable `W → Y` is also provided and activated via the
+`instrumental` flag in the data configuration. Both are used throughout the
+examples and tests.
 
 ## Training workflow
 `train.py` launches a semi-supervised training loop that mixes supervised losses

--- a/examples/scripts/train_config.yaml
+++ b/examples/scripts/train_config.yaml
@@ -1,5 +1,8 @@
 # Example configuration for training on synthetic data
 model:
   hidden_dim: 32
+  w_dim: 1
 train:
   epochs: 10
+data:
+  instrumental: false

--- a/src/causal_consistency_nn/config.py
+++ b/src/causal_consistency_nn/config.py
@@ -16,6 +16,7 @@ class ModelConfig:
 
     hidden_dim: int = 64
     num_layers: int = 2
+    w_dim: int = 1
 
 
 @dataclass
@@ -25,6 +26,7 @@ class LossWeights:
     z_yx: float = 1.0
     y_xz: float = 1.0
     x_yz: float = 1.0
+    w_x: float = 1.0
     unsup: float = 0.0
 
 
@@ -47,6 +49,9 @@ class SyntheticDataConfig:
     noise_std: float = 0.1
     missing_y_prob: float = 0.0
     num_classes: int = 2
+    w_dim: int = 1
+    w_y_strength: float = 1.0
+    instrumental: bool = False
 
 
 class Settings(BaseSettings):

--- a/src/causal_consistency_nn/data/__init__.py
+++ b/src/causal_consistency_nn/data/__init__.py
@@ -9,6 +9,7 @@ from .synthetic import (
     get_synth_dataloaders_mar,
     get_synth_dataloaders_mnar,
 )
+from .instrumental import generate_instrumental, get_instrumental_dataloaders
 
 __all__ = [
     "load_dummy",
@@ -18,4 +19,6 @@ __all__ = [
     "get_synth_dataloaders",
     "get_synth_dataloaders_mar",
     "get_synth_dataloaders_mnar",
+    "generate_instrumental",
+    "get_instrumental_dataloaders",
 ]

--- a/src/causal_consistency_nn/data/instrumental.py
+++ b/src/causal_consistency_nn/data/instrumental.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from ..config import SyntheticDataConfig
+
+
+def generate_instrumental(
+    cfg: SyntheticDataConfig, seed: int | None = None
+) -> TensorDataset:
+    """Generate data with an instrumental variable ``W -> Y``.
+
+    W ~ N(0,1)
+    X ~ N(0,1)
+    Y | W,X ~ Categorical(logits=j*(X+cfg.w_y_strength*W))
+    Z | X,Y = X + Y + eps,  eps ~ N(0, noise_std)
+    Missingness in Y follows ``cfg.missing_y_prob``.
+    """
+    g = torch.Generator()
+    if seed is not None:
+        g.manual_seed(seed)
+
+    w = torch.randn(cfg.n_samples, cfg.w_dim, generator=g)
+    x = torch.randn(cfg.n_samples, 1, generator=g)
+
+    coeffs = torch.arange(cfg.num_classes, dtype=x.dtype, device=x.device)
+    logits = (
+        x.squeeze(-1)[:, None] + cfg.w_y_strength * w.squeeze(-1)[:, None]
+    ) * coeffs
+    probs = torch.softmax(logits, dim=-1)
+    y = torch.multinomial(probs, num_samples=1, generator=g).squeeze(-1)
+
+    noise = torch.randn(cfg.n_samples, 1, generator=g) * cfg.noise_std
+    z = x + y.float().unsqueeze(-1) + noise
+
+    mask = torch.rand(cfg.n_samples, generator=g) > cfg.missing_y_prob
+    mask = mask.to(torch.bool)
+
+    return TensorDataset(w, x, y, z, mask)
+
+
+def get_instrumental_dataloaders(
+    cfg: SyntheticDataConfig, batch_size: int, seed: int | None = None
+) -> Tuple[DataLoader, DataLoader]:
+    """Return loaders for the instrumental dataset."""
+    dataset = generate_instrumental(cfg, seed)
+    w, x, y, z, mask = dataset.tensors
+
+    sup_ds = TensorDataset(w[mask], x[mask], y[mask], z[mask])
+    unsup_ds = TensorDataset(w[~mask], x[~mask], z[~mask])
+
+    sup_loader = DataLoader(sup_ds, batch_size=batch_size, shuffle=True)
+    if len(unsup_ds) > 0:
+        unsup_loader = DataLoader(unsup_ds, batch_size=batch_size, shuffle=True)
+    else:
+        unsup_loader = DataLoader(unsup_ds, batch_size=batch_size, shuffle=False)
+    return sup_loader, unsup_loader
+
+
+__all__ = ["generate_instrumental", "get_instrumental_dataloaders"]

--- a/src/causal_consistency_nn/metrics.py
+++ b/src/causal_consistency_nn/metrics.py
@@ -27,12 +27,16 @@ def log_likelihood_normal(mu: Tensor, sigma: Tensor, target: Tensor) -> Tensor:
 
 def dataset_log_likelihood(
     model: torch.nn.Module,
-    loader: Iterable[tuple[Tensor, Tensor, Tensor]],
+    loader: Iterable[tuple[Tensor, ...]],
 ) -> float:
     """Average log likelihood of ``Z`` given ``X`` and ``Y`` for a dataset."""
     total = 0.0
     count = 0
-    for x, y, z in loader:
+    for batch in loader:
+        if len(batch) == 4:
+            _, x, y, z = batch
+        else:
+            x, y, z = batch
         h = model.backbone(x)
         y_oh = F.one_hot(y, num_classes=model.y_dim).float()
         dist = model.head_z(h, y_oh)

--- a/src/causal_consistency_nn/model/__init__.py
+++ b/src/causal_consistency_nn/model/__init__.py
@@ -6,11 +6,14 @@ from .heads import (
     XgivenYZConfig,
     YgivenXZ,
     YgivenXZConfig,
+    WgivenX,
+    WgivenXConfig,
     ZgivenXY,
     ZgivenXYConfig,
 )
 from .semi_loop import EMConfig, train_em
 from .pyro_model import PyroConsistencyModel
+from .pyro_wgivenx import PyroWgivenX
 from .pyro_svi import SVIConfig, train_svi
 
 __all__ = [
@@ -22,9 +25,12 @@ __all__ = [
     "YgivenXZConfig",
     "XgivenYZ",
     "XgivenYZConfig",
+    "WgivenX",
+    "WgivenXConfig",
     "EMConfig",
     "train_em",
     "PyroConsistencyModel",
+    "PyroWgivenX",
     "SVIConfig",
     "train_svi",
 ]

--- a/src/causal_consistency_nn/model/heads.py
+++ b/src/causal_consistency_nn/model/heads.py
@@ -36,6 +36,14 @@ class XgivenYZConfig:
     x_dim: int
 
 
+@dataclass
+class WgivenXConfig:
+    """Configuration for :class:`WgivenX`."""
+
+    h_dim: int
+    w_dim: int
+
+
 class ZgivenXY(nn.Module):
     """Distribution of ``Z`` given ``X`` and ``Y``."""
 
@@ -80,11 +88,27 @@ class XgivenYZ(nn.Module):
         return Normal(mu, log_sigma.exp())
 
 
+class WgivenX(nn.Module):
+    """Distribution of ``W`` given ``X``."""
+
+    def __init__(self, cfg: WgivenXConfig) -> None:  # noqa: D401
+        super().__init__()
+        self.cfg = cfg
+        self.fc = nn.Linear(cfg.h_dim, 2 * cfg.w_dim)
+
+    def forward(self, h: torch.Tensor) -> Normal:
+        out = self.fc(h)
+        mu, log_sigma = out.chunk(2, dim=-1)
+        return Normal(mu, log_sigma.exp())
+
+
 __all__ = [
     "ZgivenXY",
     "YgivenXZ",
     "XgivenYZ",
+    "WgivenX",
     "ZgivenXYConfig",
     "YgivenXZConfig",
     "XgivenYZConfig",
+    "WgivenXConfig",
 ]

--- a/src/causal_consistency_nn/model/pyro_model.py
+++ b/src/causal_consistency_nn/model/pyro_model.py
@@ -5,10 +5,16 @@ import torch
 import torch.nn.functional as F
 
 from .backbone import Backbone, BackboneConfig
-from .heads import ZgivenXYConfig, YgivenXZConfig, XgivenYZConfig
+from .heads import (
+    ZgivenXYConfig,
+    YgivenXZConfig,
+    XgivenYZConfig,
+    WgivenXConfig,
+)
 from .pyro_zgivenxy import PyroZgivenXY
 from .pyro_ygivenxz import PyroYgivenXZ
 from .pyro_xgivenyz import PyroXgivenYZ
+from .pyro_wgivenx import PyroWgivenX
 from ..config import ModelConfig
 
 
@@ -31,6 +37,7 @@ class PyroConsistencyModel(PyroModule):
         self.head_x = PyroXgivenYZ(
             XgivenYZConfig(h_dim=h_dim, y_dim=y_dim, x_dim=x_dim)
         )
+        self.head_w = PyroWgivenX(WgivenXConfig(h_dim=h_dim, w_dim=cfg.w_dim))
         self.y_dim = y_dim
 
     def _onehot(self, y: torch.Tensor) -> torch.Tensor:
@@ -47,6 +54,10 @@ class PyroConsistencyModel(PyroModule):
     def head_x_given_yz(self, y: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
         h = self.backbone(z)
         return self.head_x(h, self._onehot(y)).mean
+
+    def head_w_given_x(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.backbone(x)
+        return self.head_w(h).mean
 
 
 __all__ = ["PyroConsistencyModel"]

--- a/src/causal_consistency_nn/model/pyro_wgivenx.py
+++ b/src/causal_consistency_nn/model/pyro_wgivenx.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pyro.nn import PyroModule
+import torch
+from torch import nn
+from pyro.distributions import Normal
+
+from .heads import WgivenXConfig
+
+
+class PyroWgivenX(PyroModule):
+    """Pyro module for ``p(W | X)``."""
+
+    def __init__(self, cfg: WgivenXConfig) -> None:  # noqa: D401
+        super().__init__()
+        self.cfg = cfg
+        self.fc = PyroModule[nn.Linear](cfg.h_dim, 2 * cfg.w_dim)
+
+    def forward(self, h: torch.Tensor) -> Normal:
+        out = self.fc(h)
+        mu, log_sigma = out.chunk(2, dim=-1)
+        return Normal(mu, log_sigma.exp())
+
+
+__all__ = ["PyroWgivenX"]

--- a/tests/test_instrumental.py
+++ b/tests/test_instrumental.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from torch.utils.data import DataLoader
+
+from causal_consistency_nn.config import SyntheticDataConfig
+from causal_consistency_nn.data.instrumental import (
+    generate_instrumental,
+    get_instrumental_dataloaders,
+)
+
+
+def test_generate_instrumental_shapes() -> None:
+    cfg = SyntheticDataConfig(n_samples=10, instrumental=True)
+    ds = generate_instrumental(cfg, seed=0)
+    w, x, y, z, m = ds.tensors
+    assert w.shape == (10, cfg.w_dim)
+    assert x.shape == (10, 1)
+    assert y.shape == (10,)
+    assert z.shape == (10, 1)
+    assert m.shape == (10,)
+
+
+def test_instrumental_dataloaders() -> None:
+    cfg = SyntheticDataConfig(n_samples=20, instrumental=True)
+    sup, unsup = get_instrumental_dataloaders(cfg, batch_size=4, seed=0)
+    assert isinstance(sup, DataLoader)
+    assert isinstance(unsup, DataLoader)
+    bw = next(iter(sup))
+    assert len(bw) == 4
+    if len(unsup) > 0:
+        bu = next(iter(unsup))
+        assert len(bu) == 3

--- a/tests/test_instrumental_training.py
+++ b/tests/test_instrumental_training.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from pathlib import Path
+from torch import nn
+
+from causal_consistency_nn import train
+from causal_consistency_nn.config import Settings
+from causal_consistency_nn.data.instrumental import get_instrumental_dataloaders
+
+
+def _run_em() -> float:
+    settings = Settings()
+    settings.data.instrumental = True
+    settings.train.epochs = 2
+    settings.train.learning_rate = 0.01
+    sup_loader, unsup_loader = get_instrumental_dataloaders(
+        settings.data, batch_size=settings.train.batch_size, seed=0
+    )
+
+    w_ex, x_ex, y_ex, z_ex = next(iter(sup_loader))
+    model = train.ConsistencyModel(
+        x_ex.shape[1], int(y_ex.max().item()) + 1, z_ex.shape[1], settings.model
+    )
+
+    mse = nn.MSELoss()
+    ce = nn.CrossEntropyLoss()
+
+    def eval_loss() -> float:
+        total = 0.0
+        for w, x, y, z in sup_loader:
+            total += (
+                mse(model.head_z_given_xy(x, y), z)
+                + ce(model.head_y_given_xz(x, z), y)
+                + mse(model.head_x_given_yz(y, z), x)
+                + mse(model.head_w_given_x(x), w)
+            ).item()
+        return total
+
+    before = eval_loss()
+    train.train_em(
+        model,
+        sup_loader,
+        unsup_loader,
+        train.EMConfig(epochs=2, lr=0.01, lambda_w=1.0),
+    )
+    after = eval_loss()
+    return after - before
+
+
+def test_em_instrumental_decreases_loss() -> None:
+    assert _run_em() < 0
+
+
+def test_svi_instrumental_decreases_loss(tmp_path: Path) -> None:
+    settings = Settings()
+    settings.train.use_pyro = True
+    settings.train.epochs = 2
+    settings.train.learning_rate = 0.01
+    settings.data.instrumental = True
+
+    sup_loader, unsup_loader = get_instrumental_dataloaders(
+        settings.data, batch_size=settings.train.batch_size, seed=0
+    )
+    w_ex, x_ex, y_ex, z_ex = next(iter(sup_loader))
+    model = train.PyroConsistencyModel(
+        x_ex.shape[1], int(y_ex.max().item()) + 1, z_ex.shape[1], settings.model
+    )
+
+    mse = nn.MSELoss()
+    ce = nn.CrossEntropyLoss()
+
+    def eval_loss() -> float:
+        total = 0.0
+        for w, x, y, z in sup_loader:
+            total += (
+                mse(model.head_z_given_xy(x, y), z)
+                + ce(model.head_y_given_xz(x, z), y)
+                + mse(model.head_x_given_yz(y, z), x)
+                + mse(model.head_w_given_x(x), w)
+            ).item()
+        return total
+
+    before = eval_loss()
+    train.train_svi(
+        model,
+        sup_loader,
+        unsup_loader,
+        train.SVIConfig(epochs=2, lr=0.01, lambda_w=1.0),
+    )
+    after = eval_loss()
+    assert after < before
+
+    out_dir = tmp_path / "out"
+    settings.train.use_pyro = True
+    train.run_training(settings, out_dir)
+    assert (out_dir / "model.pt").exists()


### PR DESCRIPTION
## Summary
- implement instrumental dataset generator
- extend configuration for instruments
- add WgivenX head with Pyro variant
- wire new head into training loops and model classes
- update scripts, evaluation and docs
- add unit and integration tests for instrumental setup

## Testing
- `ruff check .`
- `black -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853885375ec8324af6e652652c42b00