### PR TITLE
Add configurable training device

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -10,6 +10,15 @@ The simplest way to start training on the synthetic data generator is:
 python src/causal_consistency_nn/train.py --config examples/scripts/train_config.yaml
 ```
 
+To run on a GPU specify the device on the command line or via an environment
+variable:
+
+```bash
+python src/causal_consistency_nn/train.py --config examples/scripts/train_config.yaml --device cuda
+# or
+TRAIN__DEVICE=cuda python src/causal_consistency_nn/train.py --config examples/scripts/train_config.yaml
+```
+
 To train using Pyro's stochastic variational inference instead of the plain
 PyTorch loop add the `--use-pyro` flag:
 

--- a/src/causal_consistency_nn/model/lightning_loop.py
+++ b/src/causal_consistency_nn/model/lightning_loop.py
@@ -61,18 +61,25 @@ def train_lightning(
     supervised_loader: Iterable[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
     unsupervised_loader: Optional[Iterable[Tuple[torch.Tensor, torch.Tensor]]] = None,
     config: Optional[LightningConfig] = None,
+    device: torch.device | str = "cpu",
 ) -> None:
     """Train ``model`` using PyTorch Lightning."""
     cfg = config or LightningConfig()
+    torch_device = torch.device(device)
+    model.to(torch_device)
+
     module = LightningConsistencyModule(
         model, supervised_loader, unsupervised_loader, cfg
     )
+    accelerator = "gpu" if torch_device.type == "cuda" else "cpu"
     trainer = pl.Trainer(
         max_epochs=cfg.epochs,
         logger=False,
         enable_checkpointing=False,
         enable_progress_bar=False,
         enable_model_summary=False,
+        accelerator=accelerator,
+        devices=1,
     )
     trainer.fit(module)
 

--- a/tests/test_semi_loop.py
+++ b/tests/test_semi_loop.py
@@ -97,3 +97,10 @@ def test_entropy_term() -> None:
     entropy = -(torch.tensor([0.5, 0.5]) * torch.log(torch.tensor([0.5, 0.5]))).sum()
     expected = -cfg.tau * entropy
     assert torch.isclose(loss, expected, atol=1e-4)
+
+
+def test_train_em_accepts_device() -> None:
+    sup_loader, unsup_loader = create_data()
+    model = DummyModel()
+    train_em(model, sup_loader, unsup_loader, EMConfig(epochs=1), device="cpu")
+    assert all(p.device.type == "cpu" for p in model.parameters())


### PR DESCRIPTION
## Summary
- allow selecting device in EM and SVI loops
- support device in Lightning training and CLI
- document GPU option in training docs
- test device argument for training loops

## Testing
- `black -q src tests docs`
- `ruff check src tests docs --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b4d5722c8324b2a2d48c36061539