### PR TITLE
Add checkpointing and early stopping to lightning loop

### DIFF
--- a/src/causal_consistency_nn/train.py
+++ b/src/causal_consistency_nn/train.py
@@ -31,6 +31,7 @@ from .model import (
     train_em,
     train_svi,
     train_lightning,
+    LightningConfig,
 )
 
 
@@ -106,7 +107,7 @@ def run_training(settings: Settings, out_dir: Path) -> None:
         if train_lightning is None:
             raise ImportError("pytorch_lightning is not installed")
         model = ConsistencyModel(x_dim, y_dim, z_dim, settings.model)
-        em_cfg = EMConfig(
+        em_cfg = LightningConfig(
             lambda1=settings.loss.z_yx,
             lambda2=settings.loss.y_xz,
             lambda3=settings.loss.x_yz,


### PR DESCRIPTION
## Summary
- support `checkpoint_dir` and early stopping in Lightning loop
- use LightningConfig in `run_training`
- test that Lightning checkpoint is written

## Testing
- `ruff check src/causal_consistency_nn/train.py tests/test_lightning_loop.py src/causal_consistency_nn/model/lightning_loop.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b5166b908324a8b4bf8d9d17bea3